### PR TITLE
Fix dockerfile warnings in browser.Dockerfile

### DIFF
--- a/browser.Dockerfile
+++ b/browser.Dockerfile
@@ -1,5 +1,5 @@
 # Builder stage
-FROM node:18-bullseye as build-stage
+FROM node:18-bullseye AS build-stage
 
 # install required tools to build the application
 RUN apt-get update && apt-get install -y libxkbfile-dev libsecret-1-dev
@@ -26,7 +26,7 @@ RUN yarn --pure-lockfile && \
     rm -rf .git applications/electron theia-extensions/launcher theia-extensions/updater node_modules
 
 # Production stage uses a small base image
-FROM node:18-bullseye-slim as production-stage
+FROM node:18-bullseye-slim AS production-stage
 
 # Create theia user and directories
 # Application will be copied to /home/theia


### PR DESCRIPTION
#### What it does
When building this dockerfile I get warnings with docker

```
WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 29)
```

#### How to test

```
docker build -t theia -f browser.Dockerfile .
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

