### PR TITLE
Improve Release Flows

### DIFF
--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -35,15 +35,6 @@ If there was a Theia Release
 
 and adapt the code/built-ins accordingly.
 
-Next, update the `Jenkinsfile`'s `copyInstallerAndUpdateLatestYml` invocation for windows. Here we have to specficy for which olders versions we want to enable direct (incremental) updates to this version on Windows.\
-See <https://download.eclipse.org/theia/ide-preview/> for the available old versions.\
-*We plan to automate this, but at the moment it's a manual step.*
-
-E.g.:\
-`copyInstallerAndUpdateLatestYml('windows', 'TheiaIDESetup', 'exe', 'latest.yml', '1.46.0,1.46.100,1.47.0')`\
-->\
-`copyInstallerAndUpdateLatestYml('windows', 'TheiaIDESetup', 'exe', 'latest.yml', '1.46.0,1.46.100,1.47.0,1.47.100')`
-
 Finally, open a PR with your changes.
 
 ## Upgrade Dependencies


### PR DESCRIPTION
#### What it does

* compute versions to update when publishing preview
* update publishing documentation

Contributed on behalf of STMicroelectronics

#### How to test

We have to test on next release. 

However I did a test run with an adjusted Jenkinsfile and this was the result printed:

https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-411/4/execution/node/173/log/

Which shows all contents of https://download.eclipse.org/theia/ide-preview/ but latest (not a version number) and 1.54.0 (same version as current version)

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

