### PR TITLE
add notebook-support by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,11 +66,9 @@
   "theiaPluginsExcludeIds": [
     "ms-vscode.js-debug-companion",
     "VisualStudioExptTeam.vscodeintellicode",
-    "vscode.builtin-notebook-renderers",
     "vscode.extension-editing",
     "vscode.github",
     "vscode.github-authentication",
-    "vscode.ipynb",
     "vscode.microsoft-authentication"
   ],
   "workspaces": [


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
This adds the builtin extensions for notebook support by default to the plugins folder.

Currently this is kind of confusing for most users coming from vscode, that they have to install 2 additional extensions they might never have heard about (the butilin ipynb and builtin notebook renderers). Having the support available by default should make this far easier. 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

