### PR TITLE
dev: fix rebuild

### DIFF
--- a/applications/browser/package.json
+++ b/applications/browser/package.json
@@ -111,7 +111,7 @@
     "clean": "theia clean && rimraf node_modules",
     "build": "yarn -s rebuild && theia build --app-target=\"browser\" --mode development",
     "build:prod": "yarn -s rebuild && theia  build --app-target=\"browser\"",
-    "rebuild": "theia rebuild:browser --cacheRoot .",
+    "rebuild": "theia rebuild:browser --cacheRoot ../..",
     "start": "theia start --plugins=local-dir:../../plugins",
     "watch": "concurrently --kill-others -n tsc,build -c red,yellow \"tsc -b -w --preserveWatchOutput\" \"yarn -s watch:bundle\"",
     "update:theia": "ts-node ../../scripts/update-theia-version.ts",

--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -145,7 +145,7 @@
     "clean:dist": "rimraf dist",
     "build": "yarn -s rebuild && theia build --app-target=\"electron\" --mode development",
     "build:prod": "yarn -s rebuild && theia build --app-target=\"electron\"",
-    "rebuild": "theia rebuild:electron --cacheRoot .",
+    "rebuild": "theia rebuild:electron --cacheRoot ../..",
     "watch": "concurrently -n compile,build \"theiaext watch --preserveWatchOutput\" \"theia build --watch --mode development\"",
     "start": "electron scripts/theia-electron-main.js --plugins=local-dir:../../plugins",
     "start:debug": "yarn start --log-level=debug",


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
The rebuild cache of Browser and Electron needs to point to the same directory, as otherwise they do not work properly: The Browser rebuild just restores the cached modules which is not possible if they do not point to the same directory.

#### How to test

Build the Browser app after the Electron app has been built. As the cache directory is not the same, the Browser modules will not be restored from the cache. Therefore the Browser build will use the Electron modules at build time and then crash at startup.

```
yarn && yarn electron build && yarn browser build && yarn browser start
```

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

