### PR TITLE
fix: scanoss bundling

### DIFF
--- a/applications/browser/webpack.config.js
+++ b/applications/browser/webpack.config.js
@@ -7,6 +7,7 @@ const configs = require('./gen-webpack.config.js');
 const nodeConfig = require('./gen-webpack.node.config.js');
 const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 
 /**
  * Expose bundled modules on window.theia.moduleName namespace, e.g.
@@ -30,6 +31,23 @@ configs[0].plugins.push(
         ]
     })
 );
+
+/**
+ * Do no run TerserPlugin with parallel: true
+ * Each spawned node may take the full memory configured via NODE_OPTIONS / --max_old_space_size
+ * In total this may lead to OOM issues
+ */
+if (nodeConfig.config.optimization) {
+    nodeConfig.config.optimization.minimizer = [
+        new TerserPlugin({
+            parallel: false,
+            exclude: /^(lib|builtins)\//,
+            terserOptions: {
+                keep_classnames: /AbortSignal/
+            }
+        })
+    ];
+}
 
 module.exports = [
     ...configs,

--- a/applications/electron/webpack.config.js
+++ b/applications/electron/webpack.config.js
@@ -16,16 +16,19 @@ configs[0].module.rules.push({
     loader: require.resolve('@theia/application-manager/lib/expose-loader')
 }); */
 
-/** 
+/**
  * Do no run TerserPlugin with parallel: true
  * Each spawned node may take the full memory configured via NODE_OPTIONS / --max_old_space_size
  * In total this may lead to OOM issues
- */ 
+ */
 if (nodeConfig.config.optimization) {
     nodeConfig.config.optimization.minimizer = [
         new TerserPlugin({
             parallel: false,
-            exclude: /^(lib|builtins)\//
+            exclude: /^(lib|builtins)\//,
+            terserOptions: {
+                keep_classnames: /AbortSignal/
+            }
         })
     ];
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
scanoss depends on `node-fetch` <`3`. node-fetch in that version fails their instance checks, as it relies on constructor/class names which are removed by the backend bundling.

Customizes the webpack configurations to keep the class name for 'AbortSignal' as this is the one failing the check.
#### How to test

Build the Browser and/or Electron **production** builds and make sure that SCANOSS keeps working.

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

