### PR TITLE
Update Checksums for Mac Build after Signing

### DIFF
--- a/applications/browser/package.json
+++ b/applications/browser/package.json
@@ -3,7 +3,7 @@
   "name": "theia-ide-browser-app",
   "description": "Eclipse Theia IDE browser product",
   "productName": "Theia IDE",
-  "version": "1.57.101",
+  "version": "1.57.102",
   "license": "MIT",
   "author": "Eclipse Theia <theia-dev@eclipse.org>",
   "homepage": "https://github.com/eclipse-theia/theia-ide#readme",
@@ -102,7 +102,7 @@
     "@theia/vsx-registry": "1.57.1",
     "@theia/workspace": "1.57.1",
     "fs-extra": "^9.0.1",
-    "theia-ide-product-ext": "1.57.101"
+    "theia-ide-product-ext": "1.57.102"
   },
   "devDependencies": {
     "@theia/cli": "1.57.1"

--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -3,7 +3,7 @@
   "name": "theia-ide-electron-app",
   "description": "Eclipse Theia IDE product",
   "productName": "Theia IDE",
-  "version": "1.57.101",
+  "version": "1.57.102",
   "main": "scripts/theia-electron-main.js",
   "license": "MIT",
   "author": "Eclipse Theia <theia-dev@eclipse.org>",
@@ -112,9 +112,9 @@
     "@theia/vsx-registry": "1.57.1",
     "@theia/workspace": "1.57.1",
     "fs-extra": "^9.0.1",
-    "theia-ide-launcher-ext": "1.57.101",
-    "theia-ide-product-ext": "1.57.101",
-    "theia-ide-updater-ext": "1.57.101"
+    "theia-ide-launcher-ext": "1.57.102",
+    "theia-ide-product-ext": "1.57.102",
+    "theia-ide-updater-ext": "1.57.102"
   },
   "devDependencies": {
     "@theia/cli": "1.57.1",

--- a/applications/electron/scripts/update-blockmap.ts
+++ b/applications/electron/scripts/update-blockmap.ts
@@ -33,6 +33,9 @@ async function execute(): Promise<void> {
         executable
     );
     const blockMapFile = `${executablePath}${BLOCK_MAP_FILE_SUFFIX}`;
+
+    console.log(`Exe: ${executablePath}; Blockmap: ${blockMapFile}`);
+
     rmSync(blockMapFile, {
         force: true,
     });

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "4.0.0",
-  "version": "1.57.101",
+  "version": "1.57.102",
   "useWorkspaces": true,
   "npmClient": "yarn",
   "command": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.57.101",
+  "version": "1.57.102",
   "license": "MIT",
   "author": "Rob Moran <github@thegecko.org>",
   "homepage": "https://github.com/eclipse-theia/theia-ide#readme",

--- a/theia-extensions/launcher/package.json
+++ b/theia-extensions/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theia-ide-launcher-ext",
-  "version": "1.57.101",
+  "version": "1.57.102",
   "keywords": [
     "theia-extension"
   ],

--- a/theia-extensions/product/package.json
+++ b/theia-extensions/product/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "theia-ide-product-ext",
-  "version": "1.57.101",
+  "version": "1.57.102",
   "description": "Eclipse Theia IDE Product Branding",
   "dependencies": {
     "@theia/core": "1.57.1",

--- a/theia-extensions/updater/package.json
+++ b/theia-extensions/updater/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "theia-ide-updater-ext",
-  "version": "1.57.101",
+  "version": "1.57.102",
   "description": "Eclipse Theia IDE Updater",
   "dependencies": {
     "@theia/core": "1.57.1",


### PR DESCRIPTION
#### What it does
Based on the learnings from https://github.com/eclipse-theia/theia-ide/pull/439 we will now fix the checksums for the mac build as a first step. 

* also extend update checksum script to have more control over what happens (when to update paths, which files to update)
* bump versions to 1.57.102

Again this change is mainly for testing and will probably not get promoted before 1.58

#### How to test
Green Build with release dry run: https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-440/4/

Check logs with output, maybe best place is here: 
https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-440/4/flowGraphTable/

https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-440/4/execution/node/249/log/
https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-440/4/execution/node/250/log/
https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-440/4/execution/node/252/log/
https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-440/4/execution/node/253/log/

We don't have access to the zip/dmg but we can verify that only the shas get updated

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

