### PR TITLE
Make plugins writeable

### DIFF
--- a/applications/browser/package.json
+++ b/applications/browser/package.json
@@ -3,7 +3,7 @@
   "name": "theia-ide-browser-app",
   "description": "Eclipse Theia IDE browser product",
   "productName": "Theia IDE",
-  "version": "1.57.102",
+  "version": "1.57.103",
   "license": "MIT",
   "author": "Eclipse Theia <theia-dev@eclipse.org>",
   "homepage": "https://github.com/eclipse-theia/theia-ide#readme",
@@ -102,7 +102,7 @@
     "@theia/vsx-registry": "1.57.1",
     "@theia/workspace": "1.57.1",
     "fs-extra": "^9.0.1",
-    "theia-ide-product-ext": "1.57.102"
+    "theia-ide-product-ext": "1.57.103"
   },
   "devDependencies": {
     "@theia/cli": "1.57.1"

--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -3,7 +3,7 @@
   "name": "theia-ide-electron-app",
   "description": "Eclipse Theia IDE product",
   "productName": "Theia IDE",
-  "version": "1.57.102",
+  "version": "1.57.103",
   "main": "scripts/theia-electron-main.js",
   "license": "MIT",
   "author": "Eclipse Theia <theia-dev@eclipse.org>",
@@ -112,9 +112,9 @@
     "@theia/vsx-registry": "1.57.1",
     "@theia/workspace": "1.57.1",
     "fs-extra": "^9.0.1",
-    "theia-ide-launcher-ext": "1.57.102",
-    "theia-ide-product-ext": "1.57.102",
-    "theia-ide-updater-ext": "1.57.102"
+    "theia-ide-launcher-ext": "1.57.103",
+    "theia-ide-product-ext": "1.57.103",
+    "theia-ide-updater-ext": "1.57.103"
   },
   "devDependencies": {
     "@theia/cli": "1.57.1",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "4.0.0",
-  "version": "1.57.102",
+  "version": "1.57.103",
   "useWorkspaces": true,
   "npmClient": "yarn",
   "command": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.57.102",
+  "version": "1.57.103",
   "license": "MIT",
   "author": "Rob Moran <github@thegecko.org>",
   "homepage": "https://github.com/eclipse-theia/theia-ide#readme",
@@ -18,6 +18,7 @@
   "devDependencies": {
     "@eclipse-dash/nodejs-wrapper": "^0.0.1",
     "@theia/cli": "1.57.1",
+    "@types/yargs": "17.0.7",
     "@typescript-eslint/eslint-plugin": "^4.25.0",
     "@typescript-eslint/eslint-plugin-tslint": "^4.25.0",
     "@typescript-eslint/parser": "^4.25.0",
@@ -40,10 +41,11 @@
     "build:applications": "yarn build:extensions && lerna run --scope=\"theia-ide*app\" build:prod --concurrency 1",
     "build:applications:dev": "yarn build:extensions && lerna run --scope=\"theia-ide*app\" build --concurrency 1",
     "build:extensions": "lerna run --scope=\"theia-ide*ext\" build",
-    "download:plugins": "theia download:plugins --rate-limit=15 --parallel=false",
+    "download:plugins": "theia download:plugins --rate-limit=15 --parallel=false && yarn permissions:writeable",
     "package:applications": "lerna run --scope=\"theia-ide*app\" package --concurrency 1",
     "package:applications:preview": "lerna run --scope=\"theia-ide*app\" package:preview --concurrency 1",
     "package:applications:prod": "lerna run --scope=\"theia-ide*app\" package:prod --concurrency 1",
+    "permissions:writeable": "ts-node scripts/make-files-writeable.ts plugins",
     "watch": "lerna run --parallel watch",
     "test": "lerna run test",
     "electron": "yarn --cwd applications/electron",

--- a/scripts/make-files-writeable.ts
+++ b/scripts/make-files-writeable.ts
@@ -1,0 +1,62 @@
+/********************************************************************************
+ * Copyright (C) 2025 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ *
+ * SPDX-License-Identifier: MIT
+ ********************************************************************************/
+
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const argv = yargs(hideBin(process.argv))
+    .option('directory', {
+        alias: 'e',
+        type: 'string',
+        default: 'plugins',
+        description: 'The parent directory which contains the files we need to make writable',
+    })
+    .version(false)
+    .wrap(120)
+    .parseSync();
+
+execute();
+
+async function execute(): Promise<void> {
+    const directory = argv.directory;
+    console.log(`Input directory: ${directory}`);
+
+    try {
+        makeWritable(directory);
+    } catch (error) {
+        console.error(`Failed to make files writable: ${error.message}`);
+        process.exit(1);
+    }
+}
+
+function makeWritable(dir: string): void {
+    if (!fs.existsSync(dir)) {
+        throw new Error(`Directory '${dir}' does not exist.`);
+    }
+
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            makeWritable(fullPath);
+        } else if (entry.isFile()) {
+            const stats = fs.statSync(fullPath);
+            const isWritable = (stats.mode & 0o200) !== 0;
+            if (!isWritable) {
+                const isExecutable = (stats.mode & 0o111) !== 0;
+                const newMode = isExecutable ? 0o755 : 0o644;
+                console.log(`Making '${fullPath}' writable with mode '${isExecutable ? '0o755' : '0o644'}'`);
+                fs.chmodSync(fullPath, newMode);
+            }
+        }
+    }
+}

--- a/theia-extensions/launcher/package.json
+++ b/theia-extensions/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theia-ide-launcher-ext",
-  "version": "1.57.102",
+  "version": "1.57.103",
   "keywords": [
     "theia-extension"
   ],

--- a/theia-extensions/product/package.json
+++ b/theia-extensions/product/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "theia-ide-product-ext",
-  "version": "1.57.102",
+  "version": "1.57.103",
   "description": "Eclipse Theia IDE Product Branding",
   "dependencies": {
     "@theia/core": "1.57.1",

--- a/theia-extensions/updater/package.json
+++ b/theia-extensions/updater/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "theia-ide-updater-ext",
-  "version": "1.57.102",
+  "version": "1.57.103",
   "description": "Eclipse Theia IDE Updater",
   "dependencies": {
     "@theia/core": "1.57.1",


### PR DESCRIPTION
#### What it does

Follow up of https://github.com/eclipse-theia/theia-ide/pull/440
Checksums looked right and we were able to debug further. 
It looks like some files in the Java VSIX are not writable and the Mac Updater tries to change permissions there, leading to a failure. 

* make sure that plugin files are writable so that Mac may set/remove quarantine bits
* also bump patch versions

Again, this Preview will probably not be promoted, Changes will go live with 1.58

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

