### PR TITLE
Create Update Zip based on dmg

### DIFF
--- a/applications/browser/package.json
+++ b/applications/browser/package.json
@@ -3,7 +3,7 @@
   "name": "theia-ide-browser-app",
   "description": "Eclipse Theia IDE browser product",
   "productName": "Theia IDE",
-  "version": "1.57.104",
+  "version": "1.57.105",
   "license": "MIT",
   "author": "Eclipse Theia <theia-dev@eclipse.org>",
   "homepage": "https://github.com/eclipse-theia/theia-ide#readme",
@@ -104,7 +104,7 @@
     "@theia/vsx-registry": "1.57.1",
     "@theia/workspace": "1.57.1",
     "fs-extra": "^9.0.1",
-    "theia-ide-product-ext": "1.57.104"
+    "theia-ide-product-ext": "1.57.105"
   },
   "devDependencies": {
     "@theia/cli": "1.57.1"

--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -3,7 +3,7 @@
   "name": "theia-ide-electron-app",
   "description": "Eclipse Theia IDE product",
   "productName": "Theia IDE",
-  "version": "1.57.104",
+  "version": "1.57.105",
   "main": "scripts/theia-electron-main.js",
   "license": "MIT",
   "author": "Eclipse Theia <theia-dev@eclipse.org>",
@@ -112,9 +112,9 @@
     "@theia/vsx-registry": "1.57.1",
     "@theia/workspace": "1.57.1",
     "fs-extra": "^9.0.1",
-    "theia-ide-launcher-ext": "1.57.104",
-    "theia-ide-product-ext": "1.57.104",
-    "theia-ide-updater-ext": "1.57.104"
+    "theia-ide-launcher-ext": "1.57.105",
+    "theia-ide-product-ext": "1.57.105",
+    "theia-ide-updater-ext": "1.57.105"
   },
   "devDependencies": {
     "@theia/cli": "1.57.1",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "4.0.0",
-  "version": "1.57.104",
+  "version": "1.57.105",
   "useWorkspaces": true,
   "npmClient": "yarn",
   "command": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.57.104",
+  "version": "1.57.105",
   "license": "MIT",
   "author": "Rob Moran <github@thegecko.org>",
   "homepage": "https://github.com/eclipse-theia/theia-ide#readme",

--- a/theia-extensions/launcher/package.json
+++ b/theia-extensions/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theia-ide-launcher-ext",
-  "version": "1.57.104",
+  "version": "1.57.105",
   "keywords": [
     "theia-extension"
   ],

--- a/theia-extensions/product/package.json
+++ b/theia-extensions/product/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "theia-ide-product-ext",
-  "version": "1.57.104",
+  "version": "1.57.105",
   "description": "Eclipse Theia IDE Product Branding",
   "dependencies": {
     "@theia/core": "1.57.1",

--- a/theia-extensions/updater/package.json
+++ b/theia-extensions/updater/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "theia-ide-updater-ext",
-  "version": "1.57.104",
+  "version": "1.57.105",
   "description": "Eclipse Theia IDE Updater",
   "dependencies": {
     "@theia/core": "1.57.1",


### PR DESCRIPTION
#### What it does

On some (not all) Mac machines, we encounter issues with the Zip itself (even when running it directly, not just after an update), while the Dmg works fine on all test machines.

-> Investigate if producing the Zip based on the signed and notarized Dmg yields better results. It’s possible that the Eclipse signing service handles the Zip differently than the Dmg.

Result:

-> Both the Dmg and Zip are stored in the PR verification job. Both started fine on all testing machines: https://ci.eclipse.org/theia/job/Theia%20PRs/view/change-requests/job/PR-450/

-> Let’s verify if updates still work.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

