### PR TITLE
dev: use bundled backend in launch configurations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -55,7 +55,7 @@
       "type": "node",
       "request": "launch",
       "name": "Launch Browser Backend",
-      "program": "${workspaceFolder}/applications/browser/src-gen/backend/main.js",
+      "program": "${workspaceFolder}/applications/browser/lib/backend/main.js",
       "args": [
         "--hostname=0.0.0.0",
         "--port=3000",
@@ -94,7 +94,7 @@
       "type": "node",
       "request": "launch",
       "name": "Launch Browser Backend (eclipse.jdt.ls)",
-      "program": "${workspaceFolder}/applications/browser/src-gen/backend/main.js",
+      "program": "${workspaceFolder}/applications/browser/lib/backend/main.js",
       "args": [
         "--log-level=debug",
         "--root-dir=${workspaceFolder}/../eclipse.jdt.ls/org.eclipse.jdt.ls.core",
@@ -150,7 +150,7 @@
       "type": "node",
       "request": "launch",
       "args": [
-        "${workspaceFolder}/applications/browser/src-gen/backend/main.js",
+        "${workspaceFolder}/applications/browser/lib/backend/main.js",
         "${workspaceFolder}/plugins/vscode-api-tests/testWorkspace",
         "--port",
         "3030",


### PR DESCRIPTION
#### What it does

Adapts the browser launch configurations to use the bundled backend. This allows to start the browser application after it was built once, independent of the current state of the native Node module dependencies.

#### How to test

- Built the Browser application
- Build the Electron application
- Use the launch configuration to start the Browser application
- Observe that it now succeeds to start

#### Review checklist

- [X] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

