### PR TITLE
WIP: Update dialog: add Cancel button #428

### DIFF
--- a/theia-extensions/updater/package.json
+++ b/theia-extensions/updater/package.json
@@ -7,6 +7,7 @@
     "@theia/core": "1.63.0",
     "@theia/output": "1.63.0",
     "@theia/preferences": "1.63.0",
+    "builder-util-runtime": "9.1.1",
     "electron-log": "^4.3.0",
     "electron-updater": "5.3.0",
     "fs-extra": "^10.0.0",

--- a/theia-extensions/updater/src/common/updater/theia-updater.ts
+++ b/theia-extensions/updater/src/common/updater/theia-updater.ts
@@ -17,6 +17,7 @@ export interface TheiaUpdater extends JsonRpcServer<TheiaUpdaterClient> {
     onRestartToUpdateRequested(): void;
     disconnectClient(client: TheiaUpdaterClient): void;
     setUpdateChannel(channel: string): void;
+    cancel(): void;
 }
 
 export const TheiaUpdaterClient = Symbol('TheiaUpdaterClient');
@@ -30,4 +31,5 @@ export interface TheiaUpdaterClient {
     updateAvailable(available: boolean, startupCheck: boolean): void;
     notifyReadyToInstall(): void;
     reportError(error: UpdaterError): void;
+    reportCancelled(): void;
 }


### PR DESCRIPTION
#### What it does

Adds a cancel button to the updater. 

During testing I can see that the `this.cancellationToken.cancel();` method is invoked, however the updater library does not always honor it. I'm currently still debugging this

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

