### PR TITLE
update dialog: show update version in availability and restart prompt

### DIFF
--- a/theia-extensions/updater/src/common/updater/theia-updater.ts
+++ b/theia-extensions/updater/src/common/updater/theia-updater.ts
@@ -27,8 +27,17 @@ export interface UpdaterError {
     errorLogPath?: string;
 }
 
+export interface UpdateInfo {
+    version: string;
+}
+
+export interface UpdateAvailabilityInfo {
+    available: boolean;
+    updateInfo?: UpdateInfo;
+}
+
 export interface TheiaUpdaterClient {
-    updateAvailable(available: boolean, startupCheck: boolean): void;
+    updateAvailable(available: boolean, startupCheck: boolean, updateInfo?: UpdateInfo): void;
     notifyReadyToInstall(): void;
     reportError(error: UpdaterError): void;
     reportCancelled(): void;

--- a/theia-extensions/updater/src/electron-main/update/theia-updater-impl.ts
+++ b/theia-extensions/updater/src/electron-main/update/theia-updater-impl.ts
@@ -44,7 +44,7 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
 
     constructor() {
         autoUpdater.autoDownload = false;
-        autoUpdater.on('update-available', () => {
+        autoUpdater.on('update-available', (info: { version: string }) => {
             if (this.updateChannelReported) {
                 const startupCheck = this.initialCheck;
                 if (this.initialCheck) {
@@ -53,7 +53,8 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
                         this.reportOnFirstRegistration = true;
                     }
                 }
-                this.clients.forEach(c => c.updateAvailable(true, startupCheck));
+                const updateInfo = { version: info.version };
+                this.clients.forEach(c => c.updateAvailable(true, startupCheck, updateInfo));
             }
         });
         autoUpdater.on('update-not-available', () => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Closes GH-578

- extract update info once available from electron updater
- include version number in update available and restart messages if present

e.g., update available: 

<img width="521" height="117" alt="image" src="https://github.com/user-attachments/assets/e1c7dc14-838a-4e8d-884a-7c692155da48" />

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Follow the test preparation steps here: https://github.com/eclipse-theia/theia-ide/pull/549#issuecomment-3236746347
2. Test the update and check if the messages show the version to which the application will update

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

