### PR TITLE
Update Linux startup menu entry

### DIFF
--- a/theia-extensions/launcher/src/node/desktopfile-endpoint.ts
+++ b/theia-extensions/launcher/src/node/desktopfile-endpoint.ts
@@ -133,7 +133,7 @@ Terminal=false
 Type=Application
 Icon=${imagePath}
 StartupWMClass=Theia IDE
-Comment=Eclipse Theia IDE product
+Comment=IDE for cloud and desktop
 Categories=Development;IDE;`;
     }
 
@@ -147,7 +147,7 @@ Type=Application
 NoDisplay=true
 Icon=${imagePath}
 MimeType=x-scheme-handler/theia;
-Comment=Eclipse Theia IDE product
+Comment=IDE for cloud and desktop
 Categories=Development;IDE;`;
     }
 }


### PR DESCRIPTION
See the https://specifications.freedesktop.org/menu-spec/latest/ When no generic name is set, @kde displays the comment, which previously had little meaning. It is not an internal field but is user-facing!