### PR TITLE
GH-602: update release preview Jenkins build for clean build environment on Windows

### DIFF
--- a/releng/preview/Jenkinsfile.build
+++ b/releng/preview/Jenkinsfile.build
@@ -257,15 +257,15 @@ def buildInstaller(int sleepBetweenRetries) {
     sh "git clean -xdf"
     sh "yarn cache clean"
 
-    // Prepare build command
-    buildPackageCmd = 'yarn --network-timeout 100000 --frozen-lockfile --force && yarn build:extensions && yarn electron build:prod'
-
     sh 'node --version'
     sh 'printenv && yarn cache dir'
     
     // Execute build with retry capability
     try {
-        sh(script: buildPackageCmd)
+        // run install, build extensions and build electron app in separate steps
+        sh 'yarn --network-timeout 100000 --frozen-lockfile --force'
+        sh 'yarn build:extensions'
+        sh 'yarn electron build:prod'
     } catch (error) {
         retry(maxRetry) {
             sleep(sleepBetweenRetries)
@@ -276,7 +276,8 @@ def buildInstaller(int sleepBetweenRetries) {
 
     // Package the built application
     sshagent(['projects-storage.eclipse.org-bot-ssh']) {
-        sh 'yarn download:plugins && yarn electron package:prod'
+        sh 'yarn download:plugins'
+        sh 'yarn electron package:prod'
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
- fix: clean git directory to ensure a clean state for preview builds 
  - ensure the git directory is cleaned to have a clean state for the build and always force plugin downloads
    - for windows we reuse the build node which persists its workspace, hence the folder might contain outdated artifacts
    - for linux we do not reuse a node and for mac we create the first build artifacts from scratch in the GH workflow (hence the plugins are always downloaded into an empty dir)
  - do not run build in development on dry run, as it needs too much memory
  - Fixes GH-602
- fix: update to VS 2022 when using node 22 on windows 
- fix: remove superfluous re-installation of node version 
- chore: log node version also for mac runner 
- chore: separate build commands to have better overview in the logs 

Contributed on behalf of STMicroelectronics

Also done as prerequisite to this:
- Node version for ecd.theia instance was updated to 22.20.0 (see https://github.com/eclipse-cbi/jiro/pull/496)
- VS Build Tools for the Windows node were updated to 2022 (see https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6847)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- I tested on Windows and can confirm that the extensions work as expected if the plugins are properly downloaded, i.e. when the preview build starting from a clean state.
- Check the latest dry run preview build: https://ci.eclipse.org/theia/job/theia-ide-release/61/pipeline-overview/
  - Check that for the windows node, the repo is properly cleaned before the build starts


#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

