### PR TITLE
flatpak: Allow generating the Flatpak bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 **/plugins
 **/tsconfig.tsbuildinfo
 *.log
+.flatpak-builder/
+flatpak/build/
+flatpak/generated-sources.json
 license-check-summary.txt*
 .theia-ide/chatSessions
 .prompts

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "flatpak/shared-modules"]
+	path = flatpak/shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ For adopters building their own products based on this template, see the [Adopte
   - `launcher` contains a Theia extension contributing, for AppImage applications, the option to create a script that allows starting the Eclipse Theia IDE from the command line by calling the 'theia' command.
 - `patches` contains patches applied to upstream packages
 
-### Build
+### Native build
 
 For development and casual testing of the Eclipse Theia IDE, one can build it in "dev" mode. This permits building the IDE on systems with less resources, like a Raspberry Pi 4B with 4GB of RAM.
 
@@ -82,6 +82,22 @@ Production applications:
 # Build production version of the Eclipse Theia IDE app
 yarn && yarn build && yarn download:plugins
 ```
+
+### Flatpak build
+
+To build the Flatpak, you'll need `flatpak`, `flatpak-builder` and `flatpak-node-generator`.
+The first two dependencies should be available from your distro's package manager, while the last can be installed by running:
+
+```shell
+pipx install 'git+https://github.com/flatpak/flatpak-builder-tools.git#subdirectory=node'
+```
+
+Before building, make sure `yarn.lock` is up to date, since it will be used to download all Theia dependencies before building the Flatpak.
+In fact, `flatpak-builder` works in a sandbox without networking, so dependencies must be downloaded up front.
+Also, make sure git submodules are in place: `git submodule update --init`.
+
+To build the Flatpak, run the convenient command `yarn electron:flatpak`. If you don't want to install `yarn` on your system, simply run the commands
+you find in [package.json](package.json). The output files will be located in `flatpak/build`.
 
 ### Package the Applications
 

--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -5,6 +5,7 @@
   "productName": "Theia IDE",
   "version": "1.73.100",
   "main": "scripts/theia-electron-main.js",
+  "desktopName": "org.eclipse.theia.desktop",
   "license": "MIT",
   "author": "Eclipse Theia <theia-dev@eclipse.org>",
   "homepage": "https://github.com/eclipse-theia/theia-ide#readme",

--- a/flatpak/electron-builder.patch
+++ b/flatpak/electron-builder.patch
@@ -1,0 +1,14 @@
+diff --git a/applications/electron/electron-builder.yml b/applications/electron/electron-builder.yml
+index e7351de..81da41a 100644
+--- a/applications/electron/electron-builder.yml
++++ b/applications/electron/electron-builder.yml
+@@ -56,8 +56,7 @@ linux:
+     - inode/directory
+   vendor: Eclipse Foundation, Inc
+   target:
+-    - deb
+-    - AppImage
++    - dir
+   publish:
+     provider: generic
+     url: "https://download.eclipse.org/theia/ide/latest/linux"

--- a/flatpak/org.eclipse.theia.desktop
+++ b/flatpak/org.eclipse.theia.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Categories=Development;IDE;
+Keywords=Code;Eclipse;Editor;Programming;Text;VSCode;
+Comment=A modern and open IDE
+Exec=theia
+Icon=org.eclipse.theia
+Name=Theia IDE
+Terminal=false
+Type=Application
+Version=1.0

--- a/flatpak/org.eclipse.theia.metainfo.xml
+++ b/flatpak/org.eclipse.theia.metainfo.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>org.eclipse.theia</id>
+
+  <name>Theia IDE</name>
+  <summary>A modern and open IDE</summary>
+
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+
+  <developer id="org.eclipse">
+    <name>Eclipse Foundation</name>
+  </developer>
+
+  <branding>
+    <color type="primary" scheme_preference="light">#8ff0a4</color>
+    <color type="primary" scheme_preference="dark">#865e3c</color>
+  </branding>
+
+  <description>
+    <p>
+      The Theia IDE is a modern IDE built on the Theia Platform.
+    </p>
+    <p>
+      The Theia IDE is built upon the highly modular Theia platform, enabling the integration of custom extensions and the creation of fully tailored tools. It supports the VSCode API, thus it is compatible with most of the VSCode addons.
+    </p>
+  </description>
+
+  <!-- Generated with https://hughsie.github.io/oars/generate.html -->
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">mild</content_attribute>
+  </content_rating>
+
+  <releases>
+    <release version="1.67.0" date="2025-12-10">
+      <url type="details">https://eclipsesource.com/blogs/2025/12/18/eclipse-theia-1-67-release-news-and-noteworthy</url>
+    </release>
+  </releases>
+
+  <requires>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <display_length compare="ge">768</display_length>
+  </requires>
+
+  <url type="bugtracker">https://github.com/eclipse-theia/theia-ide/issues</url>
+  <url type="homepage">https://theia-ide.org</url>
+  <url type="vcs-browser">https://github.com/eclipse-theia/theia-ide</url>
+
+  <launchable type="desktop-id">org.eclipse.theia.desktop</launchable>
+  <screenshots>
+    <screenshot type="default">
+      <image>https://theia-ide.org/static/theia-screenshot-1523502d52358dd40d381c7f2969c9d0.png</image>
+    </screenshot>
+  </screenshots>
+</component>

--- a/flatpak/org.eclipse.theia.yaml
+++ b/flatpak/org.eclipse.theia.yaml
@@ -30,10 +30,6 @@ modules:
         path: ..
       - type: patch
         path: electron-builder.patch
-      - type: script
-        dest-filename: wrapper.sh
-        commands:
-          - exec zypak-wrapper /app/share/theia/theia-ide-electron-app.bin --ozone-platform-hint=auto --no-sandbox "$@"
       - type: inline
         contents: |
           --install.frozen-lockfile true
@@ -41,6 +37,8 @@ modules:
           --run.offline true
           yarn-offline-mirror ./flatpak-node/yarn-mirror
         dest-filename: .yarnrc
+      - type: file
+        path: theia.sh
       - type: file
         path: org.eclipse.theia.desktop
       - type: file
@@ -61,7 +59,7 @@ modules:
       - yarn run build
       - yarn run package:applications:prod
       - mv applications/electron/dist/linux-unpacked ${FLATPAK_DEST}/share/theia
-      - install -Dm0755 wrapper.sh ${FLATPAK_DEST}/bin/theia
+      - install -Dm0755 theia.sh ${FLATPAK_DEST}/bin/theia
       - install -Dm0644 ${FLATPAK_ID}.desktop -t ${FLATPAK_DEST}/share/applications
       - install -Dm0644 ${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo
       - install -Dm0644

--- a/flatpak/org.eclipse.theia.yaml
+++ b/flatpak/org.eclipse.theia.yaml
@@ -1,0 +1,71 @@
+app-id: org.eclipse.theia
+base: org.electronjs.Electron2.BaseApp
+base-version: '25.08'
+runtime: org.freedesktop.Sdk
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.node24
+command: theia
+finish-args:
+  - --allow=devel
+  - --device=all
+  - --env=ELECTRON_TRASH=gio
+  - --env=XCURSOR_PATH=/run/host/user-share/icons:/run/host/share/icons
+  - --filesystem=host
+  - --share=ipc
+  - --share=network
+  - --socket=fallback-x11
+  - --socket=pulseaudio
+  - --socket=ssh-auth
+  - --socket=wayland
+  - --talk-name=org.freedesktop.Flatpak # Required to run commands in the host system.
+  - --talk-name=org.freedesktop.secrets # Access to authentication services, e.g. for git.
+separate-locales: false
+modules:
+  - name: theia
+    sources:
+      - generated-sources.json
+      - type: dir
+        path: ..
+      - type: patch
+        path: electron-builder.patch
+      - type: script
+        dest-filename: wrapper.sh
+        commands:
+          - exec zypak-wrapper /app/share/theia/theia-ide-electron-app.bin --ozone-platform-hint=auto --no-sandbox "$@"
+      - type: inline
+        contents: |
+          --install.frozen-lockfile true
+          --install.offline true
+          --run.offline true
+          yarn-offline-mirror ./flatpak-node/yarn-mirror
+        dest-filename: .yarnrc
+      - type: file
+        path: org.eclipse.theia.desktop
+      - type: file
+        path: org.eclipse.theia.metainfo.xml
+    buildsystem: simple
+    build-options:
+      env:
+        NODE_OPTIONS: '--max-old-space-size=5120'
+        PUPPETEER_SKIP_DOWNLOAD: 'true'
+        TMPDIR: /run/build/theia/flatpak-node/tmp
+        XDG_CACHE_HOME: /run/build/theia/flatpak-node/cache
+        npm_config_nodedir: /usr/lib/sdk/node24
+        npm_config_offline: 'true'
+      append-path: /usr/lib/sdk/node24/bin
+    build-commands:
+      - rm -rf applications/browser
+      - yarn install
+      - yarn run build
+      - yarn run package:applications:prod
+      - mv applications/electron/dist/linux-unpacked ${FLATPAK_DEST}/share/theia
+      - install -Dm0755 wrapper.sh ${FLATPAK_DEST}/bin/theia
+      - install -Dm0644 ${FLATPAK_ID}.desktop -t ${FLATPAK_DEST}/share/applications
+      - install -Dm0644 ${FLATPAK_ID}.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo
+      - install -Dm0644
+          ${FLATPAK_DEST}/share/theia/resources/app/resources/icons/WindowIcon/512-512.png
+          ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png
+
+  - shared-modules/libsecret/libsecret.json

--- a/flatpak/theia.sh
+++ b/flatpak/theia.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# It is important to set --electronUserData and THEIA_CONFIG_DIR
+# to the same paths in both the sandbox and the native run! Otherwise
+# settings and workspaces won't be shared.
+# Since this is a Flatpak, everything will be stored within the Flatpak directory structure.
+
+default_args="--ozone-platform-hint=auto --electronUserData=$XDG_DATA_HOME"
+readonly extra_args="$*"
+
+launch_sandboxed() {
+    default_args="$default_args --no-sandbox"
+    THEIA_CONFIG_DIR="$XDG_CONFIG_HOME" \
+        exec zypak-wrapper /app/share/theia/theia-ide-electron-app.bin $default_args $extra_args
+}
+
+if [ -n "$THEIA_NO_ESCAPE_FLATPAK" ]; then
+    launch_sandboxed
+fi
+
+echo "Escaping the Flatpak sandbox…"
+
+launch_native() {
+    readonly executable_path="files/share/theia/theia-ide-electron-app.bin"
+    readonly lib_path="files/lib"
+    location="$1"
+
+    LD_LIBRARY_PATH="${location}/${lib_path}:${LD_LIBRARY_PATH}" \
+        exec flatpak-spawn \
+            --env=THEIA_CONFIG_DIR="$XDG_CONFIG_HOME" \
+            --host "${location}/${executable_path}" $default_args $extra_args
+}
+
+location="$(flatpak-spawn --host flatpak info --show-location "$FLATPAK_ID")"
+if [ $? != 0 ]; then
+    echo "Failed to get Theia installation path within Flatpak" >&2
+    launch_sandboxed
+fi
+launch_native "$location"
+
+echo "Failed to escape the Flatpak sandbox" >&2
+launch_sandboxed

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "test": "lerna run test",
     "electron": "yarn --cwd applications/electron",
     "electron-next": "yarn --cwd applications/electron-next",
+    "electron:flatpak:sources": "flatpak-node-generator yarn yarn.lock --electron-ffmpeg archive -o flatpak/generated-sources.json",
+    "electron:flatpak": "yarn electron:flatpak:sources && flatpak-builder flatpak/build flatpak/org.eclipse.theia.yaml --install-deps-from=flathub --force-clean --user",
     "browser": "yarn --cwd applications/browser",
     "update:theia": "ts-node scripts/update-theia-version.ts",
     "update:theia:children": "lerna run update:theia -- ",


### PR DESCRIPTION
#### What it does
This PR allows to generate a Flatpak bundle of theia-ide.

This PR does *not* publish Theia on Flathub. Publishing applications to Flathub requires a process in which building the Flatpak bundle is only one of the steps. I'll try to take care of it later.

This PR is related to #360, although it doesn't entirely solve it because Theia is not available on Flathub yet.
Closes #527: Theia escapes the sandbox by default. To prevent that, run it after setting the environment variable `THEIA_NO_ESCAPE_SANDBOX` to any value, e.g. `1`.

#### How to test
You should follow the Readme. After that, to run Theia, either run it from the application menu of your desktop environment or launch `flatpak run org.eclipse.theia`.

At any rate, here is the convenient command to both build and install Theia: `flatpak-builder flatpak/build flatpak/org.eclipse.theia.yaml --install-deps-from=flathub --force-clean --user --install` (note the `--install` flag).

If you run `flatpak run org.eclipse.theia`, Theia will escape the Flatpak sandbox by default. To check that, open the terminal. You should see your usual prompt, environment variables, and you should be able to browse the entire system. If you set `THEIA_NO_ESCAPE_SANDBOX`, the terminal should be limited.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

