### PR TITLE
fix AppImage read-only built-in plugin directory issues

### DIFF
--- a/applications/electron/scripts/appimage-helpers.js
+++ b/applications/electron/scripts/appimage-helpers.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Reads the plugin copy metadata file and returns its content.
+ * @param metadataPath - Path to the metadata file
+ * @returns The metadata object or undefined if not found
+ */
+function readPluginCopyMetadata(metadataPath) {
+    if (!fs.existsSync(metadataPath)) {
+        return undefined;
+    }
+    try {
+        return JSON.parse(fs.readFileSync(metadataPath, 'utf8'));
+    } catch (err) {
+        console.warn('Could not read built-in plugin copy metadata file:', err.message);
+        return undefined;
+    }
+}
+
+/**
+ * Writes the plugin copy metadata file with version and timestamp.
+ * @param metadataPath - Path to the metadata file
+ * @param version - Current version
+ */
+function writePluginCopyMetadata(metadataPath, version) {
+    const metadata = {
+        version: version,
+        copiedAt: new Date().toISOString()
+    };
+    fs.writeFileSync(metadataPath, JSON.stringify(metadata, undefined, 2));
+}
+
+/**
+ * Copies bundled plugins from AppImage to user directory if needed.
+ * @param bundledPluginsDir - Path to bundled plugins in AppImage
+ * @param userPluginsDir - Path to user built-in plugins directory
+ * @param currentVersion - Current Theia IDE version
+ * @returns true if the builtins were copied to the user dir, false if there was an error
+ */
+function copyBundledPlugins(bundledPluginsDir, userPluginsDir, currentVersion) {
+    const metadataFile = path.join(userPluginsDir, '.builtInPlugins-metadata');
+
+    // Ensure the user plugins directory exists
+    if (!fs.existsSync(userPluginsDir)) {
+        fs.mkdirSync(userPluginsDir, { recursive: true });
+    }
+
+    // Check if built-in plugins need to be copied
+    const metadata = readPluginCopyMetadata(metadataFile);
+    let shouldCopy = false;
+
+    if (!metadata) {
+        shouldCopy = true;
+    } else if (metadata.version !== currentVersion) {
+        console.log(`Theia IDE updated from ${metadata.version} to ${currentVersion}. Updating built-in plugins...`);
+        shouldCopy = true;
+    }
+
+    if (!shouldCopy) {
+        console.log('Built-in plugins were already copied.');
+        return true;
+    }
+
+    console.log(`Copying bundled plugins from AppImage to ${userPluginsDir}...`);
+    try {
+        // Clean existing plugins directory to remove old/obsolete plugins
+        fs.rmSync(userPluginsDir, { recursive: true, force: true });
+        fs.mkdirSync(userPluginsDir, { recursive: true });
+
+        const pluginEntries = fs.readdirSync(bundledPluginsDir, { withFileTypes: true });
+        for (const entry of pluginEntries) {
+            const srcPath = path.join(bundledPluginsDir, entry.name);
+            const destPath = path.join(userPluginsDir, entry.name);
+            fs.cpSync(srcPath, destPath, { recursive: true });
+        }
+        writePluginCopyMetadata(metadataFile, currentVersion);
+        console.log(`Bundled plugins copied successfully to ${userPluginsDir}.`);
+    } catch (err) {
+        console.error('Failed to copy bundled plugins:', err.message);
+        return false;
+    }
+    return true;
+}
+
+module.exports = {
+    copyBundledPlugins,
+};

--- a/applications/electron/scripts/theia-electron-main.js
+++ b/applications/electron/scripts/theia-electron-main.js
@@ -1,11 +1,34 @@
 const path = require('path');
+const fs = require('fs');
 const os = require('os');
+const { copyBundledPlugins } = require('./appimage-helpers');
 
 // Update to override the supported VS Code API version.
 // process.env.VSCODE_API_VERSION = '1.50.0'
 
-// Use a set of builtin plugins in our application.
-process.env.THEIA_DEFAULT_PLUGINS = `local-dir:${path.resolve(__dirname, '../', 'plugins')}`;
+// Detect if running as AppImage
+const isAppImage = !!process.env.APPIMAGE;
+
+const bundledPluginsDir = path.resolve(__dirname, '../', 'plugins');
+
+if (isAppImage) {
+    // When running as AppImage, use a user-writable directory for the built-in plugins
+    // The AppImage mount point (/tmp/.mount_*) is read-only
+    const configDir = process.env.THEIA_CONFIG_DIR || path.join(os.homedir(), '.theia-ide');
+    const userPluginsDir = path.join(configDir, 'builtInPlugins');
+    const packageJsonPath = path.resolve(__dirname, '../', 'package.json');
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+    const currentVersion = packageJson.version;
+
+    // Copy bundled plugins to user directory if needed (first run or version update)
+    const useUserDir = copyBundledPlugins(bundledPluginsDir, userPluginsDir, currentVersion);
+    // If copying fails, fall back to the read-only bundled directory (will be improved in follow up of GH-630)
+    process.env.THEIA_DEFAULT_PLUGINS = `local-dir:${useUserDir ? userPluginsDir : bundledPluginsDir}`;
+
+} else {
+    // Use a set of builtin plugins in our application.
+    process.env.THEIA_DEFAULT_PLUGINS = `local-dir:${bundledPluginsDir}`;
+}
 
 // Handover to the auto-generated electron application handler.
 require('../lib/backend/electron-main.js');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Copy bundled plugins to a user-writable directory for the built-in plugins since the AppImage mount point is read-only.

- Add appimage-helpers.js with plugin copy utilities
- Track plugin version metadata to update on version changes
- Skip copy on startup if plugins are already up-to-date

Fixes GH-627

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Build and package the Theia IDE locally
- Check if the Java extensions behaves correctly (see issue for setup details)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

