### PR TITLE
Improve update workflow

### DIFF
--- a/theia-extensions/updater/src/common/updater/theia-updater.ts
+++ b/theia-extensions/updater/src/common/updater/theia-updater.ts
@@ -7,17 +7,23 @@
  * SPDX-License-Identifier: MIT
  ********************************************************************************/
 
-import { JsonRpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
+import { RpcServer } from '@theia/core/lib/common/messaging/proxy-factory';
 
 export const TheiaUpdaterPath = '/services/theia-updater';
 export const TheiaUpdater = Symbol('TheiaUpdater');
-export interface TheiaUpdater extends JsonRpcServer<TheiaUpdaterClient> {
+export interface UpdaterSettings {
+    checkForUpdates: boolean;
+    checkInterval: number;
+    channel: 'stable' | 'preview';
+}
+
+export interface TheiaUpdater extends RpcServer<TheiaUpdaterClient> {
     checkForUpdates(): void;
     downloadUpdate(): void;
     onRestartToUpdateRequested(): void;
     disconnectClient(client: TheiaUpdaterClient): void;
-    setUpdateChannel(channel: string): void;
     cancel(): void;
+    setUpdaterSettings(settings: UpdaterSettings): void;
 }
 
 export const TheiaUpdaterClient = Symbol('TheiaUpdaterClient');
@@ -37,7 +43,7 @@ export interface UpdateAvailabilityInfo {
 }
 
 export interface TheiaUpdaterClient {
-    updateAvailable(available: boolean, startupCheck: boolean, updateInfo?: UpdateInfo): void;
+    updateAvailable(available: boolean, updateInfo?: UpdateInfo): void;
     notifyReadyToInstall(): void;
     reportError(error: UpdaterError): void;
     reportCancelled(): void;

--- a/theia-extensions/updater/src/electron-browser/updater/theia-updater-preferences.ts
+++ b/theia-extensions/updater/src/electron-browser/updater/theia-updater-preferences.ts
@@ -7,19 +7,28 @@
  * SPDX-License-Identifier: MIT
  ********************************************************************************/
 
-import { PreferenceSchema } from '@theia/core/lib/common/preferences/preference-schema';
+import { PreferenceSchema, PreferenceScope } from '@theia/core';
 
 export const theiaUpdaterPreferenceSchema: PreferenceSchema = {
     'properties': {
-        'updates.reportOnStart': {
+        'updates.checkForUpdates': {
             type: 'boolean',
-            description: 'Report available updates after application start.',
-            default: true
+            description: 'Automatically check for updates.',
+            default: true,
+            scope: PreferenceScope.User
+        },
+        'updates.checkInterval': {
+            type: 'number',
+            description: 'Interval in minutes between automatic update checks.',
+            default: 60,
+            scope: PreferenceScope.User
         },
         'updates.channel': {
             type: 'string',
-            enum: ['stable', 'preview'], // once we have a nightly/next build, we can add a third channel
-            default: 'stable'
+            enum: ['stable', 'preview'],
+            description: 'Channel to use for updates.',
+            default: 'stable',
+            scope: PreferenceScope.User
         },
     }
 };

--- a/theia-extensions/updater/src/electron-main/update/theia-updater-impl.ts
+++ b/theia-extensions/updater/src/electron-main/update/theia-updater-impl.ts
@@ -12,7 +12,7 @@ import * as http from 'http';
 import * as os from 'os';
 import * as path from 'path';
 import { ElectronMainApplication, ElectronMainApplicationContribution } from '@theia/core/lib/electron-main/electron-main-application';
-import { TheiaUpdater, TheiaUpdaterClient } from '../../common/updater/theia-updater';
+import { TheiaUpdater, TheiaUpdaterClient, UpdaterSettings } from '../../common/updater/theia-updater';
 import { injectable } from '@theia/core/shared/inversify';
 import { isOSX, isWindows } from '@theia/core';
 import { CancellationToken } from 'builder-util-runtime';
@@ -36,36 +36,35 @@ autoUpdater.logger.transports.file.level = 'info';
 export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationContribution {
 
     protected clients: Array<TheiaUpdaterClient> = [];
+    protected settings: UpdaterSettings = {
+        checkForUpdates: true,
+        checkInterval: 60,
+        channel: 'stable'
+    };
 
     private initialCheck: boolean = true;
-    private updateChannelReported: boolean = false;
     private reportOnFirstRegistration: boolean = false;
     private cancellationToken: CancellationToken = new CancellationToken();
+    private updateCheckTimer: NodeJS.Timeout | undefined;
 
     constructor() {
         autoUpdater.autoDownload = false;
         autoUpdater.on('update-available', (info: { version: string }) => {
-            if (this.updateChannelReported) {
-                const startupCheck = this.initialCheck;
-                if (this.initialCheck) {
-                    this.initialCheck = false;
-                    if (this.clients.length === 0) {
-                        this.reportOnFirstRegistration = true;
-                    }
+            if (this.initialCheck) {
+                this.initialCheck = false;
+                if (this.clients.length === 0) {
+                    this.reportOnFirstRegistration = true;
                 }
-                const updateInfo = { version: info.version };
-                this.clients.forEach(c => c.updateAvailable(true, startupCheck, updateInfo));
             }
+            const updateInfo = { version: info.version };
+            this.clients.forEach(c => c.updateAvailable(true, updateInfo));
         });
         autoUpdater.on('update-not-available', () => {
-            if (this.updateChannelReported) {
-                if (this.initialCheck) {
-                    this.initialCheck = false;
-                    /* do not report that no update is available on start up */
-                    return;
-                }
-                this.clients.forEach(c => c.updateAvailable(false, false));
+            if (this.initialCheck) {
+                this.initialCheck = false;
+                return;
             }
+            this.clients.forEach(c => c.updateAvailable(false));
         });
 
         autoUpdater.on('update-downloaded', () => {
@@ -82,7 +81,19 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
     }
 
     checkForUpdates(): void {
+        const feedURL = this.getFeedURL(this.settings.channel);
+        autoUpdater.setFeedURL(feedURL);
         autoUpdater.checkForUpdates();
+    }
+
+    setUpdaterSettings(settings: UpdaterSettings): void {
+        const settingsChanged = this.settings.checkForUpdates !== settings.checkForUpdates ||
+            this.settings.checkInterval !== settings.checkInterval ||
+            this.settings.channel !== settings.channel;
+        this.settings = settings;
+        if (settingsChanged) {
+            this.scheduleUpdateChecks();
+        }
     }
 
     onRestartToUpdateRequested(): void {
@@ -114,12 +125,35 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
     }
 
     onStart(application: ElectronMainApplication): void {
-        // Called when the contribution is starting. You can use both async and sync code from here.
-        this.checkForUpdates();
     }
 
     onStop(application: ElectronMainApplication): void {
-        // Invoked when the contribution is stopping. You can clean up things here. You are not allowed call async code from here.
+        this.stopUpdateCheckTimer();
+    }
+
+    private scheduleUpdateChecks(): void {
+        this.stopUpdateCheckTimer();
+
+        if (!this.settings.checkForUpdates) {
+            return;
+        }
+
+        this.checkForUpdates();
+
+        const intervalMs = Math.max(this.settings.checkInterval, 1) * 60 * 1000;
+
+        this.updateCheckTimer = setInterval(() => {
+            if (this.settings.checkForUpdates) {
+                this.checkForUpdates();
+            }
+        }, intervalMs);
+    }
+
+    private stopUpdateCheckTimer(): void {
+        if (this.updateCheckTimer) {
+            clearInterval(this.updateCheckTimer);
+            this.updateCheckTimer = undefined;
+        }
     }
 
     setClient(client: TheiaUpdaterClient | undefined): void {
@@ -127,17 +161,8 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
             this.clients.push(client);
             if (this.reportOnFirstRegistration) {
                 this.reportOnFirstRegistration = false;
-                this.clients.forEach(c => c.updateAvailable(true, true));
+                this.clients.forEach(c => c.updateAvailable(true));
             }
-        }
-    }
-
-    setUpdateChannel(channel: string): void {
-        const feedURL = this.getFeedURL(channel);
-        autoUpdater.setFeedURL(feedURL);
-        if (!this.updateChannelReported) {
-            this.updateChannelReported = true;
-            this.checkForUpdates();
         }
     }
 
@@ -164,6 +189,7 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
     }
 
     dispose(): void {
+        this.stopUpdateCheckTimer();
         this.clients.forEach(this.disconnectClient.bind(this));
     }
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Rename `updates.reportOnStart` to  `updates.checkForUpdates`, because it no longer refers to only the startup. Introduce `updates.checkInterval` which is the interval of update checks in minutes, when `updates.checkForUpdates` is enabled. Default for `updates.checkInterval` is 60 minutes. Also changed it so if the user disables the `updates.checkForUpdates` no request is sent to the download page.

Closes #546.
#### How to test

##### Test preparation
Update the download/update URL in `theia-extensions/updater/src/electron-main/update/theia-updater-impl.ts` and `applications/electron/electron-builder.yml` for your platform to `http://localhost:5000`

Run

```
yarn && yarn download:plugins
```

Build the initial AppImage (adjust for non Linux platform accordingly)

```
yarn build && yarn electron package
```

Copy `applications/electron/dist/TheiaIDE.AppImage`

We will use this to trigger the update.

Then bump the version in `applications/electron/package.json` and build the version to update to with

```
yarn && yarn build && yarn electron package
```

Copy the full `applications/electron/dist` directory somewhere.

##### Actual testing:
Inside the copied dist directory run

```
npx serve -d -u -p 5000
```

This will host the updates on localhost:5000.

Then run the AppImage we copied in the first step.

1. Notice there is an update → Click **Never**
2. Restart application → Notice no update check occurs
3. Open Settings and set `updates.checkInterval` to `1` minute
4. Enable `updates.checkForUpdates` → **Immediate** version updater dialog appears → Click **Not now**
5. Wait for 1 minute → Notice the update dialog appears again (without the "Never" option since we previously disabled and re-enabled updates, confirming the "Never" option only appears when `checkForUpdates` is `true`)

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

