### PR TITLE
Sign windows executables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,14 @@
 # We want to support as many Debian versions as possible.
 # Therefore, use the oldest Debian release that still provides the desired Node.js version.
 FROM node:24-bookworm
-RUN apt-get update && apt-get install -y libxkbfile-dev libsecret-1-dev python3
+RUN dpkg --add-architecture i386 \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+      libxkbfile-dev libsecret-1-dev python3 \
+      wine wine32 wine64 \
+ && rm -rf /var/lib/apt/lists/*
+
+# UID-agnostic wine tuning. WINEPREFIX is intentionally NOT set here; callers
+# must provide a writable path owned by the runtime user.
+ENV WINEDLLOVERRIDES="mscoree=;mshtml=" \
+    WINEDEBUG=-all

--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -173,6 +173,7 @@
     "update:theia": "ts-node ../../scripts/update-theia-version.ts",
     "update:next": "ts-node ../../scripts/update-theia-version.ts next",
     "sign:directory": "ts-node scripts/sign-directory.ts",
+    "sign:directory:windows": "ts-node scripts/sign-directory-windows.ts",
     "test": "mocha --timeout 60000 \"./test/*.spec.js\"",
     "lint": "eslint --ext js,jsx,ts,tsx scripts && eslint --ext js,jsx,ts,tsx test",
     "lint:fix": "eslint --ext js,jsx,ts,tsx scripts --fix && eslint --ext js,jsx,ts,tsx test -fix"

--- a/applications/electron/scripts/sign-directory-windows.ts
+++ b/applications/electron/scripts/sign-directory-windows.ts
@@ -1,0 +1,160 @@
+/********************************************************************************
+ * Copyright (C) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ *
+ * SPDX-License-Identifier: MIT
+ ********************************************************************************/
+
+import child_process from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { hideBin } from 'yargs/helpers';
+import yargs from 'yargs/yargs';
+import { formatBytes, replaceWithSigned, walkFiles } from './sign-utils';
+
+/**
+ * Sign Windows binaries inside an electron-builder `--dir` output (`win-unpacked`) by uploading
+ * each `.exe` to the Eclipse Authenticode signing service and writing the signed result back in
+ * place. The traversal must mirror the roots that electron-builder's `winPackager.signApp()`
+ * would sign: the top level of the unpacked directory, `resources/app.asar.unpacked/` and
+ * `swiftshader/`. The filter (`.exe` only) matches electron-builder's default `shouldSignFile`
+ * when `win.signExts` is unset.
+ */
+
+const DEFAULT_SIGN_URL = 'https://cbi.eclipse.org/authenticode/sign';
+
+const argv = yargs(hideBin(process.argv))
+    .option('directory', {
+        alias: 'd',
+        type: 'string',
+        demandOption: true,
+        description: 'The electron-builder `--dir` output directory (e.g. dist/win-unpacked) containing the unpacked Windows app'
+    })
+    .option('url', {
+        alias: 'u',
+        type: 'string',
+        default: DEFAULT_SIGN_URL,
+        description: 'The URL of the Authenticode signing service'
+    })
+    .version(false)
+    .wrap(120)
+    .parseSync();
+
+function isExeFile(filePath: string): boolean {
+    return path.extname(filePath).toLowerCase() === '.exe';
+}
+
+/**
+ * Collect files to sign by reproducing electron-builder's `winPackager.signApp()` traversal:
+ *  1. Top-level files directly under `<dir>/` (no recursion)
+ *  2. Recursive walk of `<dir>/resources/app.asar.unpacked/`
+ *  3. Recursive walk of `<dir>/swiftshader/` (if present)
+ */
+function collectFilesToSign(unpackedDir: string): string[] {
+    const topLevel = walkFiles(unpackedDir, isExeFile, { shallow: true });
+    const asarUnpacked = walkFiles(path.join(unpackedDir, 'resources', 'app.asar.unpacked'), isExeFile);
+    const swiftshader = walkFiles(path.join(unpackedDir, 'swiftshader'), isExeFile);
+    return [...topLevel, ...asarUnpacked, ...swiftshader];
+}
+
+function signFile(file: string, url: string): void {
+    const signedPath = `${file}.signed`;
+    // Remove any stale signed file from a previous run
+    if (fs.existsSync(signedPath)) {
+        fs.unlinkSync(signedPath);
+    }
+
+    const before = fs.statSync(file);
+    console.log(`Signing ${file} (${formatBytes(before.size)})...`);
+
+    const started = Date.now();
+    const result = child_process.spawnSync(
+        'curl',
+        ['-sSf', '-o', signedPath, '-F', `file=@${file}`, url],
+        { stdio: ['ignore', 'pipe', 'pipe'], encoding: 'utf-8' }
+    );
+    const durationMs = Date.now() - started;
+
+    if (result.error) {
+        throw new Error(`Failed to invoke curl for ${file}: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+        // Dump whatever curl produced to help diagnose. If curl wrote a non-binary error payload to
+        // `signedPath` (e.g. an HTML/JSON error page from the signing service), log that too.
+        if (result.stdout) {
+            console.error(`curl stdout:\n${result.stdout}`);
+        }
+        if (result.stderr) {
+            console.error(`curl stderr:\n${result.stderr}`);
+        }
+        if (fs.existsSync(signedPath)) {
+            try {
+                const body = fs.readFileSync(signedPath, 'utf-8');
+                console.error(`Response body written to ${signedPath}:\n${body}`);
+            } catch {
+                // Ignore read errors on binary/garbage content
+            }
+            try {
+                fs.unlinkSync(signedPath);
+            } catch {
+                // Best-effort cleanup
+            }
+        }
+        throw new Error(`Signing failed for ${file}: curl exited with status ${result.status}`);
+    }
+
+    if (!fs.existsSync(signedPath)) {
+        throw new Error(`Signing failed for ${file}: no output file produced at ${signedPath}`);
+    }
+
+    const signedSize = fs.statSync(signedPath).size;
+    if (signedSize === 0) {
+        fs.unlinkSync(signedPath);
+        throw new Error(`Signing failed for ${file}: signed output is empty`);
+    }
+
+    replaceWithSigned(file, signedPath);
+    console.log(`  -> signed in ${durationMs} ms (${formatBytes(signedSize)})`);
+}
+
+function main(): void {
+    const directory = path.resolve(argv.directory);
+    const url = argv.url;
+
+    if (!fs.existsSync(directory) || !fs.statSync(directory).isDirectory()) {
+        console.error(`Directory does not exist or is not a directory: ${directory}`);
+        process.exit(1);
+    }
+
+    console.log(`sign-directory-windows: directory=${directory}; url=${url}`);
+
+    const files = collectFilesToSign(directory);
+    if (files.length === 0) {
+        // Having zero files usually means the app layout changed and our walk roots no longer
+        // match what electron-builder would sign. Fail so this is caught in CI rather than
+        // silently shipping an unsigned binary.
+        console.error(
+            `No .exe files found under ${directory} in any of the expected roots (top level, ` +
+            'resources/app.asar.unpacked, swiftshader). This likely indicates a change in the ' +
+            'electron-builder output layout that sign-directory-windows has not been updated for.'
+        );
+        process.exit(1);
+    }
+
+    console.log(`Found ${files.length} file(s) to sign:`);
+    for (const file of files) {
+        console.log(`  - ${path.relative(directory, file)}`);
+    }
+
+    const overallStarted = Date.now();
+    for (const file of files) {
+        signFile(file, url);
+    }
+    const overallDuration = Date.now() - overallStarted;
+
+    console.log(`Signed ${files.length} file(s) in ${overallDuration} ms.`);
+}
+
+main();

--- a/applications/electron/scripts/sign-directory.ts
+++ b/applications/electron/scripts/sign-directory.ts
@@ -12,6 +12,7 @@ import yargs from 'yargs/yargs';
 import path from 'path';
 import fs from 'fs';
 import child_process from 'child_process';
+import { walkFiles } from './sign-utils';
 
 const signCommand = path.join(__dirname, 'sign.sh');
 const notarizeCommand = path.join(__dirname, 'notarize.sh');
@@ -75,26 +76,7 @@ function isBinaryFile(filePath: string): boolean {
 
 // Function to recursively find binaries in a directory
 function findBinariesToSign(dirPath: string): string[] {
-    const result: string[] = [];
-
-    function scanDirectory(currentPath: string): void {
-        const entries = fs.readdirSync(currentPath, { withFileTypes: true });
-
-        for (const entry of entries) {
-            const fullPath = path.join(currentPath, entry.name);
-
-            // Skip node_modules and .git directories
-            if (entry.isDirectory() &&
-                entry.name !== 'node_modules' &&
-                entry.name !== '.git') {
-                scanDirectory(fullPath);
-            } else if (entry.isFile() && isBinaryFile(fullPath)) {
-                result.push(fullPath);
-            }
-        }
-    }
-
-    scanDirectory(dirPath);
+    const result = walkFiles(dirPath, isBinaryFile, { skipDirs: ['node_modules', '.git'] });
 
     // Sort by path depth (deepest first) to ensure nested binaries are signed first
     return result.sort((a, b) => {

--- a/applications/electron/scripts/sign-utils.ts
+++ b/applications/electron/scripts/sign-utils.ts
@@ -1,0 +1,76 @@
+/********************************************************************************
+ * Copyright (C) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ *
+ * SPDX-License-Identifier: MIT
+ ********************************************************************************/
+
+import fs from 'fs';
+import path from 'path';
+
+export interface WalkOptions {
+    /** Directory names to skip entirely while recursing (e.g. `['node_modules', '.git']`). */
+    skipDirs?: string[];
+    /** If true, do not recurse into subdirectories - only list direct children. Default: false. */
+    shallow?: boolean;
+}
+
+/**
+ * Recursively walks `root` and returns all file paths for which `filter` returns `true`.
+ * If `root` does not exist, returns an empty array.
+ */
+export function walkFiles(root: string, filter: (file: string) => boolean, opts: WalkOptions = {}): string[] {
+    const result: string[] = [];
+    if (!fs.existsSync(root)) {
+        return result;
+    }
+    const skipDirs = new Set(opts.skipDirs ?? []);
+
+    const visit = (currentPath: string): void => {
+        const entries = fs.readdirSync(currentPath, { withFileTypes: true });
+        for (const entry of entries) {
+            const fullPath = path.join(currentPath, entry.name);
+            if (entry.isDirectory()) {
+                if (skipDirs.has(entry.name)) {
+                    continue;
+                }
+                if (opts.shallow) {
+                    continue;
+                }
+                visit(fullPath);
+            } else if (entry.isFile() && filter(fullPath)) {
+                result.push(fullPath);
+            }
+        }
+    };
+
+    visit(root);
+    return result;
+    }
+
+/**
+ * Replaces `originalPath` with `signedPath` on disk, preserving the file mode of the original.
+ * On POSIX `renameSync` atomically replaces the destination, so no separate unlink is needed.
+ */
+export function replaceWithSigned(originalPath: string, signedPath: string): void {
+    const originalMode = fs.statSync(originalPath).mode;
+    fs.renameSync(signedPath, originalPath);
+    fs.chmodSync(originalPath, originalMode);
+}
+
+/** Format a byte count as a human-readable string (e.g. `12.3 MB`). */
+export function formatBytes(bytes: number): string {
+    if (!Number.isFinite(bytes) || bytes < 0) {
+        return `${bytes}`;
+    }
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let value = bytes;
+    let unitIndex = 0;
+    while (value >= 1024 && unitIndex < units.length - 1) {
+        value /= 1024;
+        unitIndex++;
+    }
+    return `${value.toFixed(unitIndex === 0 ? 0 : 1)} ${units[unitIndex]}`;
+}

--- a/releng/preview/Jenkinsfile.build
+++ b/releng/preview/Jenkinsfile.build
@@ -120,26 +120,108 @@ spec:
                     }
                 }
                 stage('Windows: Create Installer') {
-                    agent {
-                        label 'windows'
-                    }
-                    steps {
-                        nodejs(nodeJSInstallationName: 'node_24.x') {
-                            // analyze memory usage
-                            bat "wmic ComputerSystem get TotalPhysicalMemory"
-                            bat "wmic OS get FreePhysicalMemory"
-                            bat "tasklist"
+                    // Windows installer creation is split into two sub-stages running on
+                    // different agents:
+                    //   1. Build the unpacked electron app on a real Windows agent.
+                    //   2. Sign each internal `.exe` via the Eclipse Authenticode service and
+                    //      package the NSIS installer from the already-signed directory on a
+                    //      Linux k8s pod
+                    stages {
+                        stage('Windows: Build unpacked') {
+                            agent {
+                                label 'windows'
+                            }
+                            steps {
+                                nodejs(nodeJSInstallationName: 'node_24.x') {
+                                    // analyze memory usage
+                                    bat "wmic ComputerSystem get TotalPhysicalMemory"
+                                    bat "wmic OS get FreePhysicalMemory"
+                                    bat "tasklist"
 
-                            buildInstaller(60)
+                                    buildUnpackedWindows()
+                                }
+                                retry(3) {
+                                    timeout(time: 30, unit: 'MINUTES') {
+                                        stash includes: 'applications/electron/dist/win-unpacked/**',
+                                              name: 'windows-unpacked'
+                                    }
+                                }
+                            }
                         }
-                        // Move Windows artifacts to windows folder for archiving
-                        sh "mkdir -p applications/electron/dist/windows"
-                        sh "find applications/electron/dist -maxdepth 1 -type f -not -path '*/\\.*' -exec mv {} applications/electron/dist/windows/ \\;"
-                        archiveArtifacts artifacts: "applications/electron/dist/windows/*", fingerprint: true
+                        stage('Windows: Sign & Package') {
+                            agent {
+                                kubernetes {
+                                    yaml """
+apiVersion: v1
+kind: Pod
+spec:
+  podRetention: never()
+  containers:
+  - name: theia-dev
+    image: eclipsetheia/theia-blueprint:builder
+    imagePullPolicy: Always
+    command:
+    - cat
+    tty: true
+    resources:
+      limits:
+        memory: "4000Mi"
+        cpu: "1000m"
+      requests:
+        memory: "512Mi"
+        cpu: "200m"
+    volumeMounts:
+    - name: global-cache
+      mountPath: /.cache
+    - name: global-yarn
+      mountPath: /.yarn
+    - name: global-npm
+      mountPath: /.npm
+    - name: electron-cache
+      mountPath: /.electron-gyp
+  volumes:
+  - name: global-cache
+    emptyDir: {}
+  - name: global-yarn
+    emptyDir: {}
+  - name: global-npm
+    emptyDir: {}
+  - name: electron-cache
+    emptyDir: {}
+"""
+                                }
+                            }
+                            environment {
+                                WINEPREFIX = "${env.WORKSPACE}/.wine-prefix"
+                            }
+                            steps {
+                                checkout scm
+                                retry(3) {
+                                    timeout(time: 30, unit: 'MINUTES') {
+                                        unstash 'windows-unpacked'
+                                    }
+                                }
+                                container('theia-dev') {
+                                    sh '''
+                                        wine --version
+                                        wine cmd /c echo wine-prefix-ok
+                                    '''
+                                    withCredentials([string(credentialsId: "github-bot-token", variable: 'GITHUB_TOKEN')]) {
+                                        sh 'yarn --network-timeout 100000 --frozen-lockfile --force'
+                                        sh 'yarn --cwd applications/electron sign:directory:windows -d dist/win-unpacked'
+                                        sh 'cd applications/electron && npx electron-builder --prepackaged dist/win-unpacked --win nsis -c.win.signAndEditExecutable=false --publish always'
+                                    }
+                                }
+                                // Move Windows artifacts to windows folder for archiving
+                                sh "mkdir -p applications/electron/dist/windows"
+                                sh "find applications/electron/dist -maxdepth 1 -type f -not -path '*/\\.*' -exec mv {} applications/electron/dist/windows/ \\;"
+                                archiveArtifacts artifacts: "applications/electron/dist/windows/*", fingerprint: true
+                            }
+                        }
                     }
                     post {
                         failure {
-                        error("Windows installer creation failed, aborting...")
+                            error("Windows installer creation failed, aborting...")
                         }
                     }
                 }
@@ -245,6 +327,22 @@ def createMacInstaller() {
     }
     
     sh "ls -al applications/electron/dist/mac-arm64 applications/electron/dist/mac-x64"
+}
+
+def buildUnpackedWindows() {
+    checkout scm
+
+    sh "git clean -xdf"
+    sh "yarn cache clean"
+
+    sh 'node --version'
+    sh 'printenv && yarn cache dir'
+
+    sh 'yarn --network-timeout 100000 --frozen-lockfile --force'
+    sh 'yarn build:extensions'
+    sh 'yarn electron build:prod'
+    sh 'yarn download:plugins'
+    sh 'cd applications/electron && npx electron-builder --dir --win -c.mac.identity=null --publish never'
 }
 
 def buildInstaller(int sleepBetweenRetries) {


### PR DESCRIPTION
#### What it does
* add a dedicated sign:directory:windows script that signs `.exe` files in `win-unpacked` via the Eclipse Authenticode service
* extract shared signing helpers for file walking, signed-file replacement, and size formatting
* split the Jenkins Windows installer stage into a Windows unpacked build step and a Linux sign-and-package step using stashed artifacts
* install wine in the builder image and configure a writable WINEPREFIX for electron-builder packaging on Linux

Contributed on behalf of STMicroelectronics

closes https://github.com/eclipse-theia/theia-ide/issues/457

#### How to test
See test build here: https://ci.eclipse.org/theia/job/tmp-win-signing/15/

Please note that the installer itself is not signed (since this would be in phase two that above build did not run through). You need to install and check the application directory. 

#### Review checklist

- [ ] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

