### PR TITLE
Unpack native build artifacts in Electron asar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 *.log
 license-check-summary.txt*
 .theia-ide/chatSessions
+.prompts

--- a/applications/browser/package.json
+++ b/applications/browser/package.json
@@ -3,7 +3,7 @@
   "name": "theia-ide-browser-app",
   "description": "Eclipse Theia IDE browser product",
   "productName": "Theia IDE",
-  "version": "1.68.200",
+  "version": "1.68.201",
   "license": "MIT",
   "author": "Eclipse Theia <theia-dev@eclipse.org>",
   "homepage": "https://github.com/eclipse-theia/theia-ide#readme",
@@ -118,7 +118,7 @@
     "@theia/vsx-registry": "1.68.2",
     "@theia/workspace": "1.68.2",
     "fs-extra": "^9.0.1",
-    "theia-ide-product-ext": "1.68.200"
+    "theia-ide-product-ext": "1.68.201"
   },
   "devDependencies": {
     "@theia/cli": "1.68.2",

--- a/applications/electron/electron-builder.yml
+++ b/applications/electron/electron-builder.yml
@@ -6,6 +6,7 @@ electronVersion: 38.4.0
 asar: true
 asarUnpack:
   - "**/lib/backend/native/**"
+  - "**/lib/build/Release/**"
 nodeGypRebuild: false
 npmRebuild: false
 

--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -3,7 +3,7 @@
   "name": "theia-ide-electron-app",
   "description": "Eclipse Theia IDE product",
   "productName": "Theia IDE",
-  "version": "1.68.200",
+  "version": "1.68.201",
   "main": "scripts/theia-electron-main.js",
   "license": "MIT",
   "author": "Eclipse Theia <theia-dev@eclipse.org>",
@@ -126,9 +126,9 @@
     "@theia/vsx-registry": "1.68.2",
     "@theia/workspace": "1.68.2",
     "fs-extra": "^9.0.1",
-    "theia-ide-launcher-ext": "1.68.200",
-    "theia-ide-product-ext": "1.68.200",
-    "theia-ide-updater-ext": "1.68.200"
+    "theia-ide-launcher-ext": "1.68.201",
+    "theia-ide-product-ext": "1.68.201",
+    "theia-ide-updater-ext": "1.68.201"
   },
   "devDependencies": {
     "@theia/cli": "1.68.2",

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "4.0.0",
-  "version": "1.68.200",
+  "version": "1.68.201",
   "useWorkspaces": true,
   "npmClient": "yarn",
   "command": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "1.68.200",
+  "version": "1.68.201",
   "license": "MIT",
   "author": "Rob Moran <github@thegecko.org>",
   "homepage": "https://github.com/eclipse-theia/theia-ide#readme",

--- a/theia-extensions/launcher/package.json
+++ b/theia-extensions/launcher/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theia-ide-launcher-ext",
-  "version": "1.68.200",
+  "version": "1.68.201",
   "keywords": [
     "theia-extension"
   ],

--- a/theia-extensions/product/package.json
+++ b/theia-extensions/product/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "theia-ide-product-ext",
-  "version": "1.68.200",
+  "version": "1.68.201",
   "description": "Eclipse Theia IDE Product Branding",
   "dependencies": {
     "@theia/core": "1.68.2",

--- a/theia-extensions/updater/package.json
+++ b/theia-extensions/updater/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "theia-ide-updater-ext",
-  "version": "1.68.200",
+  "version": "1.68.201",
   "description": "Eclipse Theia IDE Updater",
   "dependencies": {
     "@theia/core": "1.68.2",


### PR DESCRIPTION
#### What it does
* Include lib/build/Release outputs in asarUnpack. This includes the `spawn-helper` binary on Mac
* Ignore .prompts directory in git

Mac Test Build: https://ci.eclipse.org/theia/job/theia-ide-sign-notarize/86/artifact/applications/electron/dist/mac-x64/TheiaIDE.dmg

closes #664

#### How to test
Terminals on Mac should open again

No regressions on other OSes

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

