### PR TITLE
Add CLI launcher and URL handler for Theia IDE Next

### DIFF
--- a/applications/electron-next/package.json
+++ b/applications/electron-next/package.json
@@ -34,6 +34,7 @@
           "updates.channel": "next"
         },
         "electron": {
+          "uriScheme": "theia-next",
           "showWindowEarly": false,
           "splashScreenOptions": {
             "content": "resources/TheiaIDENextSplash.svg",

--- a/theia-extensions/launcher/src/browser/create-launcher-contribution.ts
+++ b/theia-extensions/launcher/src/browser/create-launcher-contribution.ts
@@ -31,34 +31,30 @@ export class CreateLauncherCommandContribution implements FrontendApplicationCon
     onStart(_app: FrontendApplication): MaybePromise<void> {
         const appConfig = FrontendApplicationConfigProvider.get();
         const applicationName = appConfig.applicationName;
-        const brandingVariant = (appConfig as Record<string, unknown>)['brandingVariant'] as string | undefined;
-        const isNext = brandingVariant === 'next';
+        const uriScheme = appConfig.electron.uriScheme;
 
-        // Only offer CLI launcher for standard (non-next) builds
-        if (!isNext) {
-            this.launcherService.isInitialized().then(async initialized => {
-                if (!initialized) {
-                    const messageContainer = document.createElement('div');
-                    // eslint-disable-next-line max-len
-                    messageContainer.textContent = nls.localizeByDefault("Would you like to install a shell command that launches the application?\nYou will be able to run the Theia IDE from the command line by typing 'theia'.");
-                    messageContainer.setAttribute('style', 'white-space: pre-line');
-                    const details = document.createElement('p');
-                    details.textContent = 'Administrator privileges are required, you will need to enter your password next.';
-                    messageContainer.appendChild(details);
-                    const dialog = new ConfirmDialog({
-                        title: nls.localizeByDefault('Create launcher'),
-                        msg: messageContainer,
-                        ok: Dialog.YES,
-                        cancel: Dialog.NO
-                    });
-                    const install = await dialog.open();
-                    this.launcherService.createLauncher(!!install);
-                    this.logger.info('Initialized application launcher.');
-                } else {
-                    this.logger.info('Application launcher was already initialized.');
-                }
-            });
-        }
+        this.launcherService.isInitialized(uriScheme).then(async initialized => {
+            if (!initialized) {
+                const messageContainer = document.createElement('div');
+                // eslint-disable-next-line max-len
+                messageContainer.textContent = nls.localizeByDefault(`Would you like to install a shell command that launches the application?\nYou will be able to run ${applicationName} from the command line by typing '${uriScheme}'.`);
+                messageContainer.setAttribute('style', 'white-space: pre-line');
+                const details = document.createElement('p');
+                details.textContent = 'Administrator privileges are required, you will need to enter your password next.';
+                messageContainer.appendChild(details);
+                const dialog = new ConfirmDialog({
+                    title: nls.localizeByDefault('Create launcher'),
+                    msg: messageContainer,
+                    ok: Dialog.YES,
+                    cancel: Dialog.NO
+                });
+                const install = await dialog.open();
+                this.launcherService.createLauncher(!!install, uriScheme);
+                this.logger.info('Initialized application launcher.');
+            } else {
+                this.logger.info('Application launcher was already initialized.');
+            }
+        });
 
         this.desktopFileService.isInitialized().then(async initialized => {
             if (!initialized) {
@@ -75,7 +71,8 @@ export class CreateLauncherCommandContribution implements FrontendApplicationCon
                 const install = await dialog.open();
                 this.desktopFileService.createOrUpdateDesktopfile(!!install, {
                     applicationName,
-                    createUrlHandler: !isNext
+                    createUrlHandler: true,
+                    uriScheme
                 });
                 this.logger.info('Created or updated .desktop file.');
             } else {

--- a/theia-extensions/launcher/src/browser/desktopfile-service.ts
+++ b/theia-extensions/launcher/src/browser/desktopfile-service.ts
@@ -13,6 +13,7 @@ import { injectable } from '@theia/core/shared/inversify';
 export interface DesktopFileOptions {
     applicationName?: string;
     createUrlHandler?: boolean;
+    uriScheme?: string;
 }
 
 @injectable()

--- a/theia-extensions/launcher/src/browser/launcher-service.ts
+++ b/theia-extensions/launcher/src/browser/launcher-service.ts
@@ -13,17 +13,18 @@ import { injectable } from '@theia/core/shared/inversify';
 @injectable()
 export class LauncherService {
 
-    async isInitialized(): Promise<boolean> {
-        const response = await fetch(new Request(`${this.endpoint()}/initialized`), {
+    async isInitialized(uriScheme?: string): Promise<boolean> {
+        const query = uriScheme ? `?uriScheme=${encodeURIComponent(uriScheme)}` : '';
+        const response = await fetch(new Request(`${this.endpoint()}/initialized${query}`), {
             body: undefined,
             method: 'GET'
         }).then(r => r.json());
         return !!response?.initialized;
     }
 
-    async createLauncher(create: boolean): Promise<void> {
+    async createLauncher(create: boolean, uriScheme?: string): Promise<void> {
         fetch(new Request(`${this.endpoint()}`), {
-            body: JSON.stringify({ create }),
+            body: JSON.stringify({ create, uriScheme }),
             method: 'PUT',
             headers: new Headers({ 'Content-Type': 'application/json' })
         });

--- a/theia-extensions/launcher/src/node/desktopfile-endpoint.ts
+++ b/theia-extensions/launcher/src/node/desktopfile-endpoint.ts
@@ -94,6 +94,7 @@ export class TheiaDesktopFileServiceEndpoint implements BackendApplicationContri
         const createOrUpdate = request.body.create;
         const applicationName: string = request.body.applicationName || 'Theia IDE';
         const createUrlHandler: boolean = request.body.createUrlHandler !== false;
+        const uriScheme: string = request.body.uriScheme || 'theia';
         const appId = applicationName.toLowerCase().replace(/\s+/g, '-');
 
         if (createOrUpdate) {
@@ -128,7 +129,7 @@ export class TheiaDesktopFileServiceEndpoint implements BackendApplicationContri
 
             if (createUrlHandler) {
                 const desktopURLFilePath = path.join(applicationsDir, `${appId}-launcher-url.desktop`);
-                fs.outputFileSync(desktopURLFilePath, this.getDesktopURLFileContents(applicationName, process.env.APPIMAGE!, imagePath));
+                fs.outputFileSync(desktopURLFilePath, this.getDesktopURLFileContents(applicationName, process.env.APPIMAGE!, imagePath, uriScheme));
             }
 
             appImageInformation.appImage = process.env.APPIMAGE!;
@@ -154,7 +155,7 @@ Comment=IDE for cloud and desktop
 Categories=Development;IDE;`;
     }
 
-    protected getDesktopURLFileContents(applicationName: string, appImagePath: string, imagePath: string): string {
+    protected getDesktopURLFileContents(applicationName: string, appImagePath: string, imagePath: string, uriScheme: string = 'theia'): string {
         return `[Desktop Entry]
 Name=${applicationName} - URL Handler
 GenericName=Integrated Development Environment
@@ -163,7 +164,7 @@ Terminal=false
 Type=Application
 NoDisplay=true
 Icon=${imagePath}
-MimeType=x-scheme-handler/theia;
+MimeType=x-scheme-handler/${uriScheme};
 Comment=IDE for cloud and desktop
 Categories=Development;IDE;`;
     }

--- a/theia-extensions/launcher/src/node/launcher-endpoint.ts
+++ b/theia-extensions/launcher/src/node/launcher-endpoint.ts
@@ -27,8 +27,6 @@ interface PathEntry {
 export class TheiaLauncherServiceEndpoint implements BackendApplicationContribution {
     protected static PATH = '/launcher';
     protected static STORAGE_FILE_NAME = 'paths.json';
-    private LAUNCHER_LINK_SOURCE = '/usr/local/bin/theia';
-
     @inject(ILogger)
     protected readonly logger: ILogger;
 
@@ -43,12 +41,14 @@ export class TheiaLauncherServiceEndpoint implements BackendApplicationContribut
         app.use(TheiaLauncherServiceEndpoint.PATH, router);
     }
 
-    private async isInitialized(_request: Request, response: Response): Promise<void> {
+    private async isInitialized(request: Request, response: Response): Promise<void> {
         if (!process.env.APPIMAGE) {
             // we are not running from an AppImage, so there's nothing to initialize
             // return true
             response.json({ initialized: true });
         }
+        const uriScheme = (request.query.uriScheme as string) || 'theia';
+        const launcherLink = `/usr/local/bin/${uriScheme}`;
         const storageFile = await getStorageFilePath(this.envServer, TheiaLauncherServiceEndpoint.STORAGE_FILE_NAME);
         if (!storageFile) {
             throw new Error('Could not resolve path to storage file.');
@@ -58,7 +58,7 @@ export class TheiaLauncherServiceEndpoint implements BackendApplicationContribut
             return;
         }
         const data = await this.readLauncherPathsFromStorage(storageFile);
-        const initialized = !!data.find(entry => entry.source === this.LAUNCHER_LINK_SOURCE);
+        const initialized = !!data.find(entry => entry.source === launcherLink);
         response.json({ initialized });
     }
 
@@ -82,7 +82,9 @@ export class TheiaLauncherServiceEndpoint implements BackendApplicationContribut
 
     private async createLauncher(request: Request, response: Response): Promise<void> {
         const shouldCreateLauncher = request.body.create;
-        const launcher = this.LAUNCHER_LINK_SOURCE;
+        const uriScheme: string = request.body.uriScheme || 'theia';
+        const launcher = `/usr/local/bin/${uriScheme}`;
+        const sudoPromptName = uriScheme === 'theia-next' ? 'Theia IDE Next' : 'Theia IDE';
         const target = process.env.APPIMAGE;
         const logFile = await this.getLogFilePath();
         const command = `printf '%s\n' '#!/bin/bash' 'exec "${target}" \\$1 &> ${logFile} &' >${launcher} && chmod +x ${launcher}`;
@@ -91,7 +93,7 @@ export class TheiaLauncherServiceEndpoint implements BackendApplicationContribut
             if (!targetExists) {
                 throw new Error('Could not find application to launch');
             }
-            sudo.exec(command, { name: 'Theia IDE' });
+            sudo.exec(command, { name: sudoPromptName });
         }
 
         const storageFile = await getStorageFilePath(this.envServer, TheiaLauncherServiceEndpoint.STORAGE_FILE_NAME);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Make launcher extension data-driven: derive CLI command name and URI scheme from app configuration instead of hardcoding them
- Remove `isNext` guards that disabled CLI launcher and URL handler for the next variant
- Add `uriScheme: "theia-next"` to electron-next frontend config
- Pass dynamic `commandName` through LauncherService to the backend endpoint, building `/usr/local/bin/${commandName}` at runtime
- Pass dynamic `uriScheme` through DesktopFileService to the desktop file endpoint for `MimeType=x-scheme-handler/${uriScheme}`
- Stable product continues to use `theia` CLI and `theia://` scheme
- Next product now uses `theia-next` CLI and `theia-next://` scheme

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

