### PR TITLE
Add script to build Theia IDE next with local Theia framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,10 @@ yarn browser start
 
 and connect to <http://localhost:3000/>
 
+### Developing with Local Theia Framework
+
+To build and test the Theia IDE against a local development version of the Theia framework, see [docs/developing-with-local-theia.md](docs/developing-with-local-theia.md).
+
 ### Troubleshooting
 
 - [_"Don't expect that you can build app for all platforms on one platform."_](https://www.electron.build/multi-platform-build)

--- a/docs/developing-with-local-theia.md
+++ b/docs/developing-with-local-theia.md
@@ -1,0 +1,223 @@
+# Developing with a Local Theia Framework
+
+This guide explains how to build and test the Theia IDE against a local development version of the [Theia framework](https://github.com/eclipse-theia/theia). This is useful when you need to:
+
+- Test Theia IDE changes against unreleased Theia features
+- Debug issues that span both the framework and the Theia IDE
+- Develop new Theia features and immediately test them in the Theia IDE
+
+## Prerequisites
+
+- Node.js and npm installed (see [Theia prerequisites](https://github.com/eclipse-theia/theia/blob/master/doc/Developing.md#prerequisites))
+- A local clone of the [Theia repository](https://github.com/eclipse-theia/theia)
+
+The recommended setup is to have both repositories cloned as siblings:
+
+```text
+parent-directory/
+  theia/          # Theia framework
+  theia-ide/      # This repository
+```
+
+This matches the script's default `--theia-path` of `../theia`. You can clone Theia anywhere and specify the path with `--theia-path`.
+
+## Important Note
+
+This script does not update the IDE version or Theia package versions in `package.json` files. It uses the current state of both repositories and relies on yarn linking to override the dependencies. If needed, you can run versioning commands (e.g., `yarn update:theia <version>`) separately before building.
+
+## Quick Start
+
+```sh
+# Clone Theia as a sibling (if not already done)
+git clone https://github.com/eclipse-theia/theia.git ../theia
+
+# Build everything
+node scripts/build-with-local-theia.js
+```
+
+## What the Script Does
+
+1. Build the local Theia framework (`npm ci` + `npm run compile`)
+2. Create yarn links for all `@theia/*` packages
+3. Link those packages into the Theia IDE
+4. Build the Theia IDE extensions and electron-next application
+5. Download required plugins
+
+## Usage
+
+### Full Build
+
+```sh
+node scripts/build-with-local-theia.js
+```
+
+### Using a Different Theia Location
+
+```sh
+node scripts/build-with-local-theia.js --theia-path /path/to/theia
+```
+
+### Incremental Development
+
+After the initial build, you can iterate faster:
+
+```sh
+# Rebuild only Theia IDE (Theia unchanged)
+node scripts/build-with-local-theia.js --skip-theia-build
+
+# Rebuild only Theia packages, then rebuild Theia IDE
+cd ../theia && npm run compile
+cd ../theia-ide && yarn build:applications:next:dev
+```
+
+### Build and Package
+
+To create a distributable application:
+
+```sh
+node scripts/build-with-local-theia.js --package
+```
+
+The packaged application will be in `applications/electron-next/dist/`.
+
+### Set Up Links Only
+
+If you want to manage builds manually:
+
+```sh
+node scripts/build-with-local-theia.js --skip-theia-build --skip-ide-build
+```
+
+### Skip Plugin Download
+
+If you already have plugins or want to skip downloading them:
+
+```sh
+node scripts/build-with-local-theia.js --skip-plugins
+```
+
+### Restore Normal Dependencies
+
+When you're done testing with the local Theia:
+
+```sh
+node scripts/build-with-local-theia.js --unlink
+```
+
+This removes all yarn links and reinstalls packages from npm.
+
+### Dry Run
+
+Preview what commands will be executed:
+
+```sh
+node scripts/build-with-local-theia.js --dry-run
+```
+
+## Running the Theia IDE (Next)
+
+After building:
+
+```sh
+yarn --cwd applications/electron-next start
+```
+
+If you packaged the application with `--package`, you can also run the packaged version directly from `applications/electron-next/dist/`.
+
+## Development Workflow
+
+A typical development workflow looks like:
+
+1. **Initial setup**: Clone Theia and run the full build
+
+    ```sh
+    git clone https://github.com/eclipse-theia/theia.git ../theia
+    node scripts/build-with-local-theia.js
+    ```
+
+2. **Make changes in Theia**: Edit files in `../theia`
+
+3. **Rebuild Theia**:
+
+    ```sh
+    cd ../theia && npm run compile
+    ```
+
+4. **Rebuild and run Theia IDE**:
+
+    ```sh
+    cd ../theia-ide
+    yarn build:applications:next:dev
+    yarn --cwd applications/electron-next start
+    ```
+
+5. **When done**: Restore npm dependencies
+
+    ```sh
+    node scripts/build-with-local-theia.js --unlink
+    ```
+
+## Command Reference
+
+| Option                | Description                                          |
+|-----------------------|------------------------------------------------------|
+| `--theia-path <path>` | Path to local Theia repository (default: `../theia`) |
+| `--skip-theia-build`  | Skip building Theia packages (use if already built)  |
+| `--skip-ide-build`    | Skip building Theia IDE (use for linking only)       |
+| `--skip-plugins`      | Skip downloading plugins                             |
+| `--package`           | Package the electron-next application after building |
+| `--unlink`            | Remove links and restore npm dependencies            |
+| `--dry-run`           | Print commands without executing them                |
+| `--help`              | Show help message                                    |
+
+## Troubleshooting
+
+### "Theia directory not found"
+
+Make sure you have cloned the Theia repository:
+
+```sh
+git clone https://github.com/eclipse-theia/theia.git ../theia
+```
+
+Or specify the correct path:
+
+```sh
+node scripts/build-with-local-theia.js --theia-path /correct/path/to/theia
+```
+
+### "Package not found in local Theia"
+
+Some `@theia/*` packages used by the Theia IDE may not exist in your Theia checkout. This can happen if:
+
+- You're on an older Theia branch that doesn't have newer packages
+- The package is from a different source
+
+The script will warn about missing packages but continue with available ones.
+
+### Build Errors After Switching Branches
+
+If you switch branches in either repository, clean and rebuild:
+
+```sh
+# In theia-ide
+git clean -xfd
+node scripts/build-with-local-theia.js
+
+# Or if only Theia packages changed
+cd ../theia && git clean -xfd && npm ci && npm run compile
+cd ../theia-ide && yarn build:applications:next:dev
+```
+
+### Restoring Clean State
+
+If things get into a bad state:
+
+```sh
+# Unlink and restore npm packages
+node scripts/build-with-local-theia.js --unlink
+
+# Full clean rebuild
+git clean -xfd
+yarn && yarn build:dev && yarn download:plugins
+```

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "build:applications": "lerna run --scope=\"theia-ide*app\" --ignore=\"theia-ide-next*\" build:prod --concurrency 1",
     "build:applications:dev": "lerna run --scope=\"theia-ide*app\" --ignore=\"theia-ide-next*\" build --concurrency 1",
     "build:applications:next": "lerna run --scope=\"theia-ide-next*\" build:prod --concurrency 1",
+    "build:applications:next:dev": "lerna run --scope=\"theia-ide-next*\" build --concurrency 1",
     "build:extensions": "lerna run --scope=\"theia-ide*ext\" build",
     "download:plugins": "theia download:plugins --rate-limit=15 --parallel=false && yarn permissions:writeable",
     "package:applications": "lerna run --scope=\"theia-ide*app\" --ignore=\"theia-ide-next*\" package --concurrency 1",

--- a/scripts/build-with-local-theia.js
+++ b/scripts/build-with-local-theia.js
@@ -1,0 +1,397 @@
+#!/usr/bin/env node
+
+/**
+ * Script to build Theia IDE with a local Theia framework development version.
+ *
+ * This allows testing Theia IDE changes against local Theia framework modifications
+ * without publishing to npm first. It expects a locally cloned version of the
+ * Theia repository (https://github.com/eclipse-theia/theia) that will be linked
+ * into the Theia IDE build.
+ *
+ * Usage:
+ *   node scripts/build-with-local-theia.js [options]
+ *
+ * Options:
+ *   --theia-path <path>   Path to local Theia repository [default: ../theia]
+ *   --skip-theia-build    Skip building Theia packages (use if already built) [default: false]
+ *   --skip-ide-build      Skip building Theia IDE (use for linking only) [default: false]
+ *   --skip-plugins        Skip downloading plugins [default: false]
+ *   --package             Package the electron-next application after building [default: false]
+ *   --unlink              Remove links and restore npm dependencies [default: false]
+ *   --dry-run             Print commands without executing them [default: false]
+ *   --help                Show this help message
+ *
+ * See docs/developing-with-local-theia.md for detailed documentation.
+ */
+
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT_DIR = path.resolve(__dirname, '..');
+const DEFAULT_THEIA_PATH = path.resolve(ROOT_DIR, '..', 'theia');
+
+// Parse command line arguments
+const args = process.argv.slice(2);
+
+function getArgValue(flag, defaultValue) {
+    const index = args.indexOf(flag);
+    if (index !== -1 && args[index + 1]) {
+        return args[index + 1];
+    }
+    return defaultValue;
+}
+
+const options = {
+    theiaPath: path.resolve(getArgValue('--theia-path', DEFAULT_THEIA_PATH)),
+    skipTheiaBuild: args.includes('--skip-theia-build'),
+    skipIdeBuild: args.includes('--skip-ide-build'),
+    skipPlugins: args.includes('--skip-plugins'),
+    package: args.includes('--package'),
+    unlink: args.includes('--unlink'),
+    dryRun: args.includes('--dry-run'),
+    help: args.includes('--help')
+};
+
+if (options.help) {
+    console.log(`
+Usage: node scripts/build-with-local-theia.js [options]
+
+This script builds the Theia IDE against a local Theia framework checkout,
+allowing you to test framework changes without publishing to npm first.
+
+The script uses yarn link to connect the local Theia packages to the IDE build.
+
+Note: This script does not update the IDE version or Theia package versions.
+It uses the current state of both repositories. If needed, you can run
+versioning commands (e.g., yarn update:theia) separately before building.
+
+Prerequisites:
+  A local clone of the Theia repository (https://github.com/eclipse-theia/theia).
+  By default, the script expects it at ../theia (next to the theia-ide directory).
+
+Options:
+  --theia-path <path>   Path to local Theia repository [default: ../theia]
+  --skip-theia-build    Skip building Theia packages (use if already built) [default: false]
+  --skip-ide-build      Skip building Theia IDE (use for linking only) [default: false]
+  --skip-plugins        Skip downloading plugins [default: false]
+  --package             Package the electron-next application after building [default: false]
+  --unlink              Remove links and restore npm dependencies [default: false]
+  --dry-run             Print commands without executing them [default: false]
+  --help                Show this help message
+
+See docs/developing-with-local-theia.md for detailed documentation and examples.
+`);
+    process.exit(0);
+}
+
+/**
+ * Execute a shell command
+ */
+function run(cmd, cwd = ROOT_DIR, description = '') {
+    if (description) {
+        console.log(`\n${'='.repeat(60)}`);
+        console.log(`> ${description}`);
+        console.log(`${'='.repeat(60)}`);
+    }
+    console.log(`$ ${cmd}`);
+    console.log(`  (in ${cwd})\n`);
+
+    if (options.dryRun) {
+        console.log('[DRY RUN] Command not executed');
+        return '';
+    }
+
+    try {
+        execSync(cmd, {
+            cwd,
+            stdio: 'inherit',
+            env: {
+                ...process.env,
+                NODE_OPTIONS: '--max_old_space_size=4096'
+            }
+        });
+    } catch (error) {
+        console.error(`\nCommand failed: ${cmd}`);
+        throw error;
+    }
+}
+
+/**
+ * Read JSON file
+ */
+function readJson(filePath) {
+    return JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+}
+
+/**
+ * Get all @theia/* packages from a package.json
+ */
+function getTheiaDependencies(packageJsonPath) {
+    const pkg = readJson(packageJsonPath);
+    const theiaDeps = new Set();
+
+    for (const deps of [pkg.dependencies, pkg.devDependencies]) {
+        if (deps) {
+            for (const dep of Object.keys(deps)) {
+                if (dep.startsWith('@theia/')) {
+                    theiaDeps.add(dep);
+                }
+            }
+        }
+    }
+
+    return theiaDeps;
+}
+
+/**
+ * Find all Theia packages in the local Theia repository
+ */
+function findTheiaPackages(theiaPath) {
+    const packagesDir = path.join(theiaPath, 'packages');
+    const devPackagesDir = path.join(theiaPath, 'dev-packages');
+    const packages = new Map();
+
+    for (const dir of [packagesDir, devPackagesDir]) {
+        if (!fs.existsSync(dir)) {
+            continue;
+        }
+
+        for (const entry of fs.readdirSync(dir)) {
+            const pkgJsonPath = path.join(dir, entry, 'package.json');
+            if (fs.existsSync(pkgJsonPath)) {
+                const pkg = readJson(pkgJsonPath);
+                if (pkg.name && pkg.name.startsWith('@theia/')) {
+                    packages.set(pkg.name, path.join(dir, entry));
+                }
+            }
+        }
+    }
+
+    return packages;
+}
+
+/**
+ * Collect all @theia/* dependencies from IDE packages
+ */
+function collectAllTheiaDependencies() {
+    const allDeps = new Set();
+
+    // Root package.json
+    const rootDeps = getTheiaDependencies(path.join(ROOT_DIR, 'package.json'));
+    rootDeps.forEach(d => allDeps.add(d));
+
+    // Applications
+    for (const app of ['electron', 'browser', 'electron-next']) {
+        const appPkgPath = path.join(ROOT_DIR, 'applications', app, 'package.json');
+        if (fs.existsSync(appPkgPath)) {
+            getTheiaDependencies(appPkgPath).forEach(d => allDeps.add(d));
+        }
+    }
+
+    // Extensions
+    for (const ext of ['launcher', 'product', 'updater']) {
+        const extPkgPath = path.join(ROOT_DIR, 'theia-extensions', ext, 'package.json');
+        if (fs.existsSync(extPkgPath)) {
+            getTheiaDependencies(extPkgPath).forEach(d => allDeps.add(d));
+        }
+    }
+
+    return allDeps;
+}
+
+/**
+ * Build Theia
+ */
+function buildTheia() {
+    run('npm ci', options.theiaPath, 'Install Theia dependencies');
+    // Compile all Theia packages, no need to build the applications in this case
+    run('npm run compile', options.theiaPath, 'Compile Theia packages');
+}
+
+/**
+ * Create yarn link for Theia packages
+ */
+function linkTheiaPackages() {
+    console.log(`\n${'='.repeat(60)}`);
+    console.log('> Creating yarn links for Theia packages');
+    console.log(`${'='.repeat(60)}\n`);
+
+    const theiaPackages = findTheiaPackages(options.theiaPath);
+    const requiredDeps = collectAllTheiaDependencies();
+
+    console.log(`Found ${theiaPackages.size} Theia packages`);
+    console.log(`Theia IDE requires ${requiredDeps.size} @theia/* packages\n`);
+
+    const linked = [];
+    const missing = [];
+
+    // Create links in Theia packages
+    for (const dep of requiredDeps) {
+        const pkgPath = theiaPackages.get(dep);
+        if (pkgPath) {
+            if (!options.dryRun) {
+                console.log(`Linking ${dep}...`);
+                try {
+                    execSync('yarn link', { cwd: pkgPath, stdio: 'pipe' });
+                } catch (e) {
+                    // Link might already exist, that's fine
+                }
+            }
+            linked.push(dep);
+        } else {
+            missing.push(dep);
+        }
+    }
+
+    if (options.dryRun) {
+        console.log(`Would create yarn links for ${linked.length} packages`);
+    }
+
+    if (missing.length > 0) {
+        console.log('\nWarning: The following packages were not found in local Theia:');
+        missing.forEach(m => console.log(`  - ${m}`));
+    }
+
+    // Link packages in IDE
+    console.log(`\nLinking ${linked.length} packages in IDE...`);
+    if (linked.length > 0) {
+        const linkCmd = `yarn link ${linked.join(' ')}`;
+        console.log(`$ ${linkCmd}`);
+        if (!options.dryRun) {
+            execSync(linkCmd, { cwd: ROOT_DIR, stdio: 'inherit' });
+        } else {
+            console.log('[DRY RUN] Command not executed');
+        }
+    }
+
+    console.log(`\n${options.dryRun ? 'Would link' : 'Linked'} ${linked.length} packages`);
+    return linked;
+}
+
+/**
+ * Unlink Theia packages and restore npm dependencies
+ */
+function unlinkTheiaPackages() {
+    console.log(`\n${'='.repeat(60)}`);
+    console.log('> Removing yarn links and restoring npm dependencies');
+    console.log(`${'='.repeat(60)}\n`);
+
+    const requiredDeps = collectAllTheiaDependencies();
+
+    // Unlink packages
+    if (options.dryRun) {
+        console.log(`Would unlink ${requiredDeps.size} packages`);
+    } else {
+        for (const dep of requiredDeps) {
+            console.log(`Unlinking ${dep}...`);
+            try {
+                execSync(`yarn unlink ${dep}`, { cwd: ROOT_DIR, stdio: 'pipe' });
+            } catch (e) {
+                // Ignore errors if not linked
+            }
+        }
+    }
+
+    // Reinstall to restore npm versions
+    run('yarn --force', ROOT_DIR, 'Reinstall npm dependencies');
+
+    console.log('\nLinks removed and npm dependencies restored');
+}
+
+/**
+ * Build IDE
+ */
+function buildIde() {
+    run('yarn', ROOT_DIR, 'Install IDE dependencies');
+    run('yarn build:extensions', ROOT_DIR, 'Build IDE extensions');
+    run('yarn build:applications:next:dev', ROOT_DIR, 'Build electron-next application');
+    if (!options.skipPlugins) {
+        run('yarn download:plugins', ROOT_DIR, 'Download plugins');
+    } else {
+        console.log('\nSkipping plugin download (--skip-plugins)');
+    }
+}
+
+/**
+ * Package the electron-next application
+ */
+function packageApp() {
+    run('yarn package:applications:next', ROOT_DIR, 'Package electron-next application');
+}
+
+/**
+ * Main function
+ */
+async function main() {
+    console.log('\nBuild Theia IDE with local Theia framework\n');
+    console.log(`Theia path: ${options.theiaPath}`);
+
+    const startTime = Date.now();
+
+    if (options.unlink) {
+        unlinkTheiaPackages();
+    } else {
+        // Verify Theia exists
+        if (!fs.existsSync(options.theiaPath)) {
+            console.error(`\nError: Theia directory not found at ${options.theiaPath}`);
+            console.error('\nPlease clone the Theia repository first:');
+            console.error('  git clone https://github.com/eclipse-theia/theia.git ../theia');
+            console.error('\nOr specify a different location with --theia-path');
+            process.exit(1);
+        }
+
+        // Build Theia
+        if (!options.skipTheiaBuild) {
+            buildTheia();
+        } else {
+            console.log('\nSkipping Theia build (--skip-theia-build)');
+        }
+
+        // Link packages
+        linkTheiaPackages();
+
+        // Build IDE
+        if (!options.skipIdeBuild) {
+            buildIde();
+        } else {
+            console.log('\nSkipping IDE build (--skip-ide-build)');
+        }
+
+        // Package if requested
+        if (options.package) {
+            packageApp();
+        }
+    }
+
+    const elapsed = ((Date.now() - startTime) / 1000 / 60).toFixed(2);
+
+    console.log(`\n${'='.repeat(60)}`);
+    console.log('Done!');
+    console.log(`${'='.repeat(60)}`);
+    console.log(`Total time: ${elapsed} minutes`);
+
+    if (!options.unlink && !options.package) {
+        console.log(`
+Next steps:
+  - Run the IDE: yarn --cwd applications/electron-next start
+  - Make changes in Theia, rebuild: (cd ${options.theiaPath} && npm run compile)
+  - Rebuild IDE: yarn build:applications:next:dev
+  - Package the app: node scripts/build-with-local-theia.js --skip-theia-build --skip-ide-build --package
+  - When done, restore npm deps: node scripts/build-with-local-theia.js --unlink
+`);
+    }
+
+    if (options.package) {
+        console.log('\nPackaged application is in: applications/electron-next/dist/');
+    }
+
+    if (options.dryRun) {
+        console.log('\nThis was a dry run. No commands were actually executed.');
+    }
+}
+
+main().catch(error => {
+    console.error('\nBuild failed:', error.message);
+    process.exit(1);
+});


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Resolves #670

Adds build-with-local-theia.js script that allows building and testing the Theia IDE next against a local Theia framework checkout without publishing to npm first.

The script:
- Builds the local Theia framework (npm ci + npm run compile)
- Creates yarn links for all @theia/* packages
- Links them into the Theia IDE next build
- Builds the IDE extensions and all applications
- Optionally packages the application

Options include --skip-theia-build, --skip-ide-build, --skip-plugins, --package, --unlink, --dry-run and --help.

Includes documentation in docs/developing-with-local-theia.md with usage examples, development workflow, and troubleshooting guide.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Try the build locally with your local Theia clone, check the help page of the script or the documentation for details.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

