### PR TITLE
Upgrade Electron from 39.7.0 to 39.8.7

### DIFF
--- a/applications/electron-next/electron-builder.yml
+++ b/applications/electron-next/electron-builder.yml
@@ -2,7 +2,7 @@ appId: eclipse.theia.next
 productName: TheiaIDENext
 copyright: Copyright © 2020-2025 Eclipse Foundation, Inc
 electronDist: ../../node_modules/electron/dist
-electronVersion: 39.7.0
+electronVersion: 39.8.7
 asar: true
 asarUnpack:
   - "**/lib/backend/native/**"

--- a/applications/electron-next/package.json
+++ b/applications/electron-next/package.json
@@ -148,7 +148,7 @@
     "app-builder-lib": "26.0.12",
     "chai": "^4.3.10",
     "concurrently": "^3.5.0",
-    "electron": "39.7.0",
+    "electron": "39.8.7",
     "electron-builder": "26.0.12",
     "electron-chromedriver": "^28.2.8",
     "electron-mocha": "^12.3.0",

--- a/applications/electron/electron-builder.yml
+++ b/applications/electron/electron-builder.yml
@@ -2,7 +2,7 @@ appId: eclipse.theia
 productName: TheiaIDE
 copyright: Copyright © 2020-2025 Eclipse Foundation, Inc
 electronDist: ../../node_modules/electron/dist
-electronVersion: 39.7.0
+electronVersion: 39.8.7
 asar: true
 asarUnpack:
   - "**/lib/backend/native/**"

--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -142,7 +142,7 @@
     "app-builder-lib": "26.0.12",
     "chai": "^4.3.10",
     "concurrently": "^3.5.0",
-    "electron": "39.7.0",
+    "electron": "39.8.7",
     "electron-builder": "26.0.12",
     "electron-chromedriver": "^28.2.8",
     "electron-mocha": "^12.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7236,10 +7236,10 @@ electron-window@^0.8.0:
   dependencies:
     is-electron-renderer "^2.0.0"
 
-electron@39.7.0:
-  version "39.7.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-39.7.0.tgz#ecdf9a7e27fc5b9280276a81151301f363f274a4"
-  integrity sha512-Rz5QvP1pTqoU1DPRrG3EeX2oWBtS3uRmd6Z/wzZsb2e/iIUsrT+XcBaAhFr4FW48gDc8uP2wYVyY5Aamha/5Zg==
+electron@39.8.7:
+  version "39.8.7"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-39.8.7.tgz#d4dab3bfa53cd1b1c67b5b76b8e96a7e6a2532bd"
+  integrity sha512-B3TmzbUEeIvrhJ0QcoFp8/tgnVA3vsm0wkdYWzC22hsk9zTVqkzyrrz40cjd0nMTTIrGWxxfDO2tdQTCMe9Bjw==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^22.7.7"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Relies on https://github.com/eclipse-theia/theia/pull/17329

- Fixes intermittent crash on Windows when hovering/clicking the splash screen during startup
- Caused by a use-after-free in non-client hit-test handling during frameless window teardown (electron/electron#50040)
- Bug introduced in Electron 39.6.1, fixed in 39.8.1 (electron/electron#50042)

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- On Windows: during startup of the electron application interact with the splash screen (hover or click) and observe the application starts as expected.
- Besides that, the application behaves as expected after the version update

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

