### PR TITLE
fix: generate app-update.yml for Windows auto-updater

### DIFF
--- a/applications/electron/scripts/generate-app-update-yml.js
+++ b/applications/electron/scripts/generate-app-update-yml.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+/********************************************************************************
+ * Copyright (C) 2026 STMicroelectronics and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ *
+ * SPDX-License-Identifier: MIT
+ ********************************************************************************/
+
+// Generates app-update.yml for the Windows auto-updater.
+//
+// The normal electron-builder flow generates this file during afterPack, but
+// only when the target is "nsis" or "appx". The Windows CI build splits
+// packaging into two steps:
+//   1. `electron-builder --dir` (target = "dir") → app-update.yml is skipped
+//   2. `electron-builder --prepackaged` → afterPack does not run
+//
+// This script bridges that gap by writing the file before step 2.
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+const electronDir = path.resolve(__dirname, '..');
+const pkg = require(path.join(electronDir, 'package.json'));
+const builderConfig = yaml.load(fs.readFileSync(path.join(electronDir, 'electron-builder.yml'), 'utf8'));
+
+const winPublish = builderConfig.win.publish;
+const version = pkg.version;
+
+// Expand ${version} macro in the URL, matching electron-builder's macro expansion
+const url = winPublish.url.replace('${version}', version);
+
+const appUpdateYml = {
+    provider: winPublish.provider,
+    url,
+    ...(winPublish.useMultipleRangeRequest !== undefined && { useMultipleRangeRequest: winPublish.useMultipleRangeRequest }),
+    updaterCacheDirName: `${pkg.name}-updater`
+};
+
+const outPath = path.join(electronDir, 'dist', 'win-unpacked', 'resources', 'app-update.yml');
+fs.writeFileSync(outPath, yaml.dump(appUpdateYml, { lineWidth: -1 }));
+console.log(`Generated ${outPath}`);
+console.log(fs.readFileSync(outPath, 'utf8'));

--- a/releng/preview/Jenkinsfile.build
+++ b/releng/preview/Jenkinsfile.build
@@ -209,6 +209,11 @@ spec:
                                     withCredentials([string(credentialsId: "github-bot-token", variable: 'GITHUB_TOKEN')]) {
                                         sh 'yarn --network-timeout 100000 --frozen-lockfile --force'
                                         sh 'yarn --cwd applications/electron sign:directory:windows -d dist/win-unpacked'
+                                        // Generate app-update.yml for the Windows auto-updater.
+                                        // electron-builder skips this when using --dir (step 1) because the
+                                        // target is "dir", not "nsis", and --prepackaged (step 2) does not
+                                        // re-run the afterPack lifecycle.
+                                        sh 'node applications/electron/scripts/generate-app-update-yml.js'
                                         sh 'cd applications/electron && npx electron-builder --prepackaged dist/win-unpacked --win nsis -c.win.signAndEditExecutable=false --publish always'
                                     }
                                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

The two-step Windows build (--dir then --prepackaged) skips app-update.yml generation because electron-builder only creates it for nsis/appx targets. Add a script that reads the publish config from electron-builder.yml and writes the file into the unpacked directory before NSIS packaging.

Fixes #710 

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Check Theia IDE v1.71.101 on Windows if the file exists at: `C:\Users\user\AppData\Local\Programs\TheiaIDE\resources\app-update.yml`

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

