### PR TITLE
feat(launcher): auto-refresh stale .desktop files and improve URL handler registration

### DIFF
--- a/theia-extensions/launcher/src/browser/create-launcher-contribution.ts
+++ b/theia-extensions/launcher/src/browser/create-launcher-contribution.ts
@@ -56,28 +56,37 @@ export class CreateLauncherCommandContribution implements FrontendApplicationCon
             }
         });
 
-        this.desktopFileService.isInitialized().then(async initialized => {
-            if (!initialized) {
-                const messageContainer = document.createElement('div');
-                // eslint-disable-next-line max-len
-                messageContainer.textContent = nls.localizeByDefault(`Would you like to create a .desktop file for ${applicationName}?\nThis will make it easier to open ${applicationName} directly\nfrom your applications menu and enables further features.`);
-                messageContainer.setAttribute('style', 'white-space: pre-line');
-                const dialog = new ConfirmDialog({
-                    title: nls.localizeByDefault('Create .desktop file'),
-                    msg: messageContainer,
-                    ok: Dialog.YES,
-                    cancel: Dialog.NO
-                });
-                const install = await dialog.open();
-                this.desktopFileService.createOrUpdateDesktopfile(!!install, {
+        this.desktopFileService.getState({ applicationName, uriScheme }).then(async state => {
+            if (state === 'up-to-date') {
+                this.logger.info('Desktop file already up to date.');
+                return;
+            }
+            if (state === 'needs-silent-update') {
+                await this.desktopFileService.createOrUpdateDesktopfile(true, {
                     applicationName,
                     createUrlHandler: true,
                     uriScheme
                 });
-                this.logger.info('Created or updated .desktop file.');
-            } else {
-                this.logger.info('Desktop file was not updated or created.');
+                this.logger.info('Desktop file silently updated to match current launcher template.');
+                return;
             }
+            const messageContainer = document.createElement('div');
+            // eslint-disable-next-line max-len
+            messageContainer.textContent = nls.localizeByDefault(`Would you like to create a .desktop file for ${applicationName}?\nThis will make it easier to open ${applicationName} directly\nfrom your applications menu and enables further features.`);
+            messageContainer.setAttribute('style', 'white-space: pre-line');
+            const dialog = new ConfirmDialog({
+                title: nls.localizeByDefault('Create .desktop file'),
+                msg: messageContainer,
+                ok: Dialog.YES,
+                cancel: Dialog.NO
+            });
+            const install = await dialog.open();
+            this.desktopFileService.createOrUpdateDesktopfile(!!install, {
+                applicationName,
+                createUrlHandler: true,
+                uriScheme
+            });
+            this.logger.info('Created or updated .desktop file.');
         });
     }
 }

--- a/theia-extensions/launcher/src/browser/desktopfile-service.ts
+++ b/theia-extensions/launcher/src/browser/desktopfile-service.ts
@@ -10,24 +10,27 @@
 import { Endpoint } from '@theia/core/lib/browser';
 import { injectable } from '@theia/core/shared/inversify';
 
+export type DesktopFileState = 'up-to-date' | 'needs-silent-update' | 'needs-prompt';
+
 export interface DesktopFileOptions {
-    applicationName?: string;
+    applicationName: string;
+    uriScheme: string;
     createUrlHandler?: boolean;
-    uriScheme?: string;
 }
 
 @injectable()
 export class DesktopFileService {
 
-    async isInitialized(): Promise<boolean> {
-        const response = await fetch(new Request(`${this.endpoint()}/initialized`), {
-            body: undefined,
-            method: 'GET'
-        }).then(r => r.json());
-        return !!response?.initialized;
+    async getState(options: DesktopFileOptions): Promise<DesktopFileState> {
+        const params = new URLSearchParams({
+            applicationName: options.applicationName,
+            uriScheme: options.uriScheme
+        });
+        const response = await fetch(new Request(`${this.endpoint()}/state?${params}`), { method: 'GET' }).then(r => r.json());
+        return response?.state ?? 'needs-prompt';
     }
 
-    async createOrUpdateDesktopfile(create: boolean, options?: DesktopFileOptions): Promise<void> {
+    async createOrUpdateDesktopfile(create: boolean, options: DesktopFileOptions): Promise<void> {
         fetch(new Request(`${this.endpoint()}`), {
             body: JSON.stringify({ create, ...options }),
             method: 'PUT',

--- a/theia-extensions/launcher/src/node/desktopfile-endpoint.ts
+++ b/theia-extensions/launcher/src/node/desktopfile-endpoint.ts
@@ -16,6 +16,9 @@ import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { getStorageFilePath } from './launcher-util';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { execFile } from 'child_process';
+
+export type DesktopFileState = 'up-to-date' | 'needs-silent-update' | 'needs-prompt';
 
 interface DesktopFileInformation {
     appImage: string;
@@ -34,41 +37,40 @@ export class TheiaDesktopFileServiceEndpoint implements BackendApplicationContri
     configure(app: Application): void {
         const router = Router();
         router.put('/', (request, response) => this.createOrUpdateDesktopfile(request, response));
-        router.get('/initialized', (request, response) => this.isInitialized(request, response));
+        router.get('/state', (request, response) => this.getState(request, response));
         app.use(json());
         app.use(TheiaDesktopFileServiceEndpoint.PATH, router);
     }
 
-    protected async isInitialized(_request: Request, response: Response): Promise<void> {
+    protected async getState(request: Request, response: Response): Promise<void> {
+        const applicationName = request.query.applicationName;
+        const uriScheme = request.query.uriScheme;
+        if (typeof applicationName !== 'string' || typeof uriScheme !== 'string') {
+            response.status(400).json({ error: 'applicationName and uriScheme query parameters are required' });
+            return;
+        }
+        response.json({ state: await this.computeState(applicationName, uriScheme) });
+    }
+
+    protected async computeState(applicationName: string, uriScheme: string): Promise<DesktopFileState> {
         if (!process.env.APPIMAGE) {
-            // we only want to create Desktop Files when running as an App Image
-            response.json({ initialized: true });
+            return 'up-to-date';
         }
         if (process.env.HOME === undefined) {
-            // log error but assume initialized, since we can't proceed
             console.error('Desktop files can only be created if there is a set HOME directory');
-            response.json({ initialized: true });
+            return 'up-to-date';
         }
         const storageFile = await getStorageFilePath(this.envServer, TheiaDesktopFileServiceEndpoint.STORAGE_FILE_NAME);
         if (!storageFile) {
             throw new Error('Could not resolve path to storage file.');
         }
-        if (!fs.existsSync(storageFile)) {
-            response.json({ initialized: false });
-            return;
+        const info = await this.readAppImageInformationFromStorage(storageFile);
+        if (!info || info.appImage !== process.env.APPIMAGE) {
+            return info?.declined?.includes(process.env.APPIMAGE) ? 'up-to-date' : 'needs-prompt';
         }
-        const appImageInformation = await this.readAppImageInformationFromStorage(storageFile);
-        if (appImageInformation === undefined) {
-            response.json({ initialized: false });
-            return;
-        }
-        if (appImageInformation.declined !== undefined && appImageInformation.declined.includes(process.env.APPIMAGE!)) {
-            // we don't want to create Desktop Files for this App Image
-            response.json({ initialized: true });
-            return;
-        }
-        const initialized = appImageInformation.appImage === process.env.APPIMAGE;
-        response.json({ initialized });
+        // Prior consent recorded for this AppImage — re-apply silently if the on-disk
+        // files no longer match what the current launcher template would render.
+        return this.isOnDiskUpToDate(applicationName, uriScheme) ? 'up-to-date' : 'needs-silent-update';
     }
 
     protected async readAppImageInformationFromStorage(storageFile: string): Promise<DesktopFileInformation | undefined> {
@@ -85,21 +87,25 @@ export class TheiaDesktopFileServiceEndpoint implements BackendApplicationContri
     }
 
     protected async createOrUpdateDesktopfile(request: Request, response: Response): Promise<void> {
+        const { applicationName, uriScheme } = request.body;
+        if (typeof applicationName !== 'string' || typeof uriScheme !== 'string') {
+            response.status(400).json({ error: 'applicationName and uriScheme are required' });
+            return;
+        }
+        const createOrUpdate: boolean = !!request.body.create;
+        const createUrlHandler: boolean = request.body.createUrlHandler !== false;
+        const appId = this.getAppId(applicationName);
+
         const storageFile = await getStorageFilePath(this.envServer, TheiaDesktopFileServiceEndpoint.STORAGE_FILE_NAME);
         let appImageInformation: DesktopFileInformation | undefined = await this.readAppImageInformationFromStorage(storageFile);
         if (appImageInformation === undefined) {
             appImageInformation = { appImage: '', declined: [] };
         }
 
-        const createOrUpdate = request.body.create;
-        const applicationName: string = request.body.applicationName || 'Theia IDE';
-        const createUrlHandler: boolean = request.body.createUrlHandler !== false;
-        const uriScheme: string = request.body.uriScheme || 'theia';
-        const appId = applicationName.toLowerCase().replace(/\s+/g, '-');
-
         if (createOrUpdate) {
             const iconFileName = appId + '-electron-app.png';
-            const applicationsDir = path.join(process.env.HOME!, '.local', 'share', 'applications');
+            const applicationsDir = this.getApplicationsDir();
+            fs.ensureDirSync(applicationsDir);
             const imagePath = path.join(applicationsDir, iconFileName);
             if (!fs.existsSync(imagePath)) {
                 const appDir = process.env.APPDIR;
@@ -127,13 +133,16 @@ export class TheiaDesktopFileServiceEndpoint implements BackendApplicationContri
             const desktopFilePath = path.join(applicationsDir, `${appId}-launcher.desktop`);
             fs.outputFileSync(desktopFilePath, this.getDesktopFileContents(applicationName, process.env.APPIMAGE!, imagePath));
 
+            const urlDesktopFileName = `${appId}-launcher-url.desktop`;
             if (createUrlHandler) {
-                const desktopURLFilePath = path.join(applicationsDir, `${appId}-launcher-url.desktop`);
+                const desktopURLFilePath = path.join(applicationsDir, urlDesktopFileName);
                 fs.outputFileSync(desktopURLFilePath, this.getDesktopURLFileContents(applicationName, process.env.APPIMAGE!, imagePath, uriScheme));
             }
 
             appImageInformation.appImage = process.env.APPIMAGE!;
             fs.outputJSONSync(storageFile, appImageInformation);
+
+            await this.refreshDesktopDatabase(applicationsDir, createUrlHandler ? { uriScheme, urlDesktopFileName } : undefined);
         } else {
             appImageInformation.declined.push(process.env.APPIMAGE!);
             fs.outputJSONSync(storageFile, appImageInformation);
@@ -155,7 +164,7 @@ Comment=IDE for cloud and desktop
 Categories=Development;IDE;`;
     }
 
-    protected getDesktopURLFileContents(applicationName: string, appImagePath: string, imagePath: string, uriScheme: string = 'theia'): string {
+    protected getDesktopURLFileContents(applicationName: string, appImagePath: string, imagePath: string, uriScheme: string): string {
         return `[Desktop Entry]
 Name=${applicationName} - URL Handler
 GenericName=Integrated Development Environment
@@ -167,5 +176,59 @@ Icon=${imagePath}
 MimeType=x-scheme-handler/${uriScheme};
 Comment=IDE for cloud and desktop
 Categories=Development;IDE;`;
+    }
+
+    protected getAppId(applicationName: string): string {
+        return applicationName.toLowerCase().replace(/\s+/g, '-');
+    }
+
+    protected getApplicationsDir(): string {
+        // XDG Base Directory Spec: $XDG_DATA_HOME/applications, falling back to
+        // $HOME/.local/share/applications when XDG_DATA_HOME is unset or empty.
+        const xdgDataHome = process.env.XDG_DATA_HOME || path.join(process.env.HOME!, '.local', 'share');
+        return path.join(xdgDataHome, 'applications');
+    }
+
+    protected isOnDiskUpToDate(applicationName: string, uriScheme: string): boolean {
+        const appId = this.getAppId(applicationName);
+        const applicationsDir = this.getApplicationsDir();
+        const imagePath = path.join(applicationsDir, `${appId}-electron-app.png`);
+        const launcherPath = path.join(applicationsDir, `${appId}-launcher.desktop`);
+        const urlPath = path.join(applicationsDir, `${appId}-launcher-url.desktop`);
+        const expectedLauncher = this.getDesktopFileContents(applicationName, process.env.APPIMAGE!, imagePath);
+        const expectedUrl = this.getDesktopURLFileContents(applicationName, process.env.APPIMAGE!, imagePath, uriScheme);
+        return this.fileMatches(launcherPath, expectedLauncher) && this.fileMatches(urlPath, expectedUrl);
+    }
+
+    protected fileMatches(filePath: string, expectedContents: string): boolean {
+        try {
+            return fs.readFileSync(filePath, 'utf8') === expectedContents;
+        } catch {
+            return false;
+        }
+    }
+
+    // Best-effort refresh so xdg-open / gio open immediately route the registered scheme
+    // to the freshly written .desktop file. Errors are logged but do not fail the request.
+    protected async refreshDesktopDatabase(applicationsDir: string, urlHandler?: { uriScheme: string; urlDesktopFileName: string }): Promise<void> {
+        if (process.platform !== 'linux') {
+            return;
+        }
+        const tasks: Promise<void>[] = [this.runCommand('update-desktop-database', [applicationsDir])];
+        if (urlHandler) {
+            tasks.push(this.runCommand('xdg-mime', ['default', urlHandler.urlDesktopFileName, `x-scheme-handler/${urlHandler.uriScheme}`]));
+        }
+        await Promise.all(tasks);
+    }
+
+    protected runCommand(command: string, args: string[]): Promise<void> {
+        return new Promise(resolve => {
+            execFile(command, args, { timeout: 5000 }, error => {
+                if (error) {
+                    console.warn(`Launcher: '${command} ${args.join(' ')}' failed:`, error.message);
+                }
+                resolve();
+            });
+        });
     }
 }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->
Replace the binary `isInitialized` check with a three-state `getState` API ('up-to-date', 'needs-silent-update', 'needs-prompt') so that previously-consented .desktop files are silently re-applied when their on-disk contents no longer match the current launcher template, only prompting the user on first-time setup.

- Add `computeState`/`isOnDiskUpToDate` to compare rendered launcher and URL handler files against what is on disk
- Resolve the applications directory via the XDG Base Directory spec ($XDG_DATA_HOME with $HOME/.local/share fallback) and ensure it exists
- Refresh the desktop database (update-desktop-database, xdg-mime) after writing so the registered URI scheme routes immediately
- Require and validate `applicationName` and `uriScheme` on both the /state and PUT endpoints, returning 400 on missing parameters
#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
##### Setup

Run once to create a sandbox so you don't touch your real
`~/.local/share/applications` or `~/.theia-ide`:

```bash
# from the repo root
mkdir -p /tmp/launchertest/appdir /tmp/launchertest/xdg /tmp/launchertest/config
# a dummy icon so the icon-copy path is exercised
cp ~/.local/share/applications/theia-ide-electron-app.png /tmp/launchertest/appdir/ 2>/dev/null || \
  touch /tmp/launchertest/appdir/icon.png
# a fake "AppImage" file (contents irrelevant)
touch /tmp/launchertest/Theia-IDE.AppImage
```

Build the application
- `yarn && yarn build:extensions && yarn electron build`

Export the sandbox env vars **once** in your shell — every test below assumes
they're set, so you can just run `yarn electron start` to restart between tests:

```bash
export APPIMAGE=/tmp/launchertest/Theia-IDE.AppImage
export APPDIR=/tmp/launchertest/appdir
export XDG_DATA_HOME=/tmp/launchertest/xdg
export THEIA_CONFIG_DIR=/tmp/launchertest/config
```

##### Test 1 — First run prompts (`needs-prompt`)

1. Make sure the sandbox is clean: `rm -rf /tmp/launchertest/xdg /tmp/launchertest/config`
2. Start the app: `yarn electron start`.
3. **Expect:** the **"Create .desktop file"** dialog appears (alongside the
   unrelated "Create launcher" shell-command dialog — dismiss that one with **No**).
   > ⚠️ **Two dialogs appear on every fresh start.** When the env vars below are set,
   > the launcher extension opens **two independent prompts**:
   > 1. **"Create launcher"** — the older `/usr/local/bin/<scheme>` shell-command
   >    flow (writes `paths.json`, asks for sudo). **Not under test here — click No.**
   > 2. **"Create .desktop file"** — the flow this document tests (writes
   >    `desktopfile.json` + `.desktop` files).
4. Click **Yes** on the **"Create .desktop file"** dialog.
5. **Expect:** both `.desktop` files + the icon appear under
   `/tmp/launchertest/xdg/applications/`, and `desktopfile.json` contains
   `"appImage": "/tmp/launchertest/Theia-IDE.AppImage"`. Verify:

   ```bash
   ls /tmp/launchertest/xdg/applications/
   cat /tmp/launchertest/config/globalStorage/theia-ide-launcher/desktopfile.json
   ```

##### Test 2 — No change on restart (`up-to-date`)

1. Close and restart the app with the **same** command.
2. **Expect:** **no dialog**, files unchanged. Backend log says
   `Desktop file already up to date.`

##### Test 3 — Silent self-heal (`needs-silent-update`) — the headline feature

1. With consent already recorded (after Test 1), corrupt/modify the on-disk file:

   ```bash
   echo "stale" >> /tmp/launchertest/xdg/applications/theia-ide-launcher.desktop
   ```

2. Restart the app with the same command.
3. **Expect:** **no dialog**, but the file is **silently rewritten** back to the
   correct template. Log says `Desktop file silently updated…`. Verify the `stale`
   line is gone:

   ```bash
   tail -n1 /tmp/launchertest/xdg/applications/theia-ide-launcher.desktop
   ```

##### Test 4 — New AppImage version re-prompts

1. Lets say there is a new AppImage path:

   ```bash
   touch /tmp/launchertest/Theia-IDE-v2.AppImage
   export APPIMAGE=/tmp/launchertest/Theia-IDE-v2.AppImage
   yarn electron start
   ```

2. **Expect:** the dialog appears again (stored appImage ≠ current).
3. After clicking yes, `/tmp/launchertest/Theia-IDE-v2.AppImage` is in the dektopfile:

```bash
cat /tmp/launchertest/config/globalStorage/theia-ide-launcher/desktopfile.json 
```

##### Test 5 — URL handler registration

Check the scheme handler was registered:

```bash
XDG_DATA_HOME=/tmp/launchertest/xdg xdg-mime query default x-scheme-handler/theia
```

**Expect:** `theia-ide-launcher-url.desktop`.

##### Test 6 — Decline is remembered

1. Clean state again: `rm -rf /tmp/launchertest/xdg/* /tmp/launchertest/config/*`
2. Start the app → dialog appears → click **No**.
3. **Expect:** `desktopfile.json` lists the AppImage path under `"declined"`, and
   **no** `.desktop` files are written.
   ```bash
   cat /tmp/launchertest/config/globalStorage/theia-ide-launcher/desktopfile.json
   ```
4. Restart with the same command.
5. **Expect:** **no dialog** (declined AppImage → treated as `up-to-date`).

## Cleanup

```bash
rm -rf /tmp/launchertest
```
#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

