### PR TITLE
feat(launcher): auto-refresh stale CLI launcher script

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "watch": "lerna run --parallel watch",
     "test": "lerna run test",
     "electron": "yarn --cwd applications/electron",
+    "electron-next": "yarn --cwd applications/electron-next",
     "browser": "yarn --cwd applications/browser",
     "update:theia": "ts-node scripts/update-theia-version.ts",
     "update:theia:children": "lerna run update:theia -- ",

--- a/theia-extensions/launcher/src/browser/create-launcher-contribution.ts
+++ b/theia-extensions/launcher/src/browser/create-launcher-contribution.ts
@@ -9,14 +9,22 @@
 
 import { ConfirmDialog, Dialog, FrontendApplication, FrontendApplicationContribution, StorageService } from '@theia/core/lib/browser';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
-import { ILogger, MaybePromise } from '@theia/core/lib/common';
+import { Command, CommandContribution, CommandRegistry, ILogger, MaybePromise } from '@theia/core/lib/common';
 import { nls } from '@theia/core/lib/common/nls';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { LauncherService } from './launcher-service';
 import { DesktopFileService } from './desktopfile-service';
 
+export namespace LauncherCommands {
+    export const CREATE_LAUNCHER: Command = {
+        id: 'theia-ide.launcher.create',
+        label: 'Create CLI Launcher',
+        category: 'Theia IDE'
+    };
+}
+
 @injectable()
-export class CreateLauncherCommandContribution implements FrontendApplicationContribution {
+export class CreateLauncherCommandContribution implements FrontendApplicationContribution, CommandContribution {
 
     @inject(StorageService)
     protected readonly storageService: StorageService;
@@ -33,27 +41,39 @@ export class CreateLauncherCommandContribution implements FrontendApplicationCon
         const applicationName = appConfig.applicationName;
         const uriScheme = appConfig.electron.uriScheme;
 
-        this.launcherService.isInitialized(uriScheme).then(async initialized => {
-            if (!initialized) {
-                const messageContainer = document.createElement('div');
-                // eslint-disable-next-line max-len
-                messageContainer.textContent = nls.localizeByDefault(`Would you like to install a shell command that launches the application?\nYou will be able to run ${applicationName} from the command line by typing '${uriScheme}'.`);
-                messageContainer.setAttribute('style', 'white-space: pre-line');
-                const details = document.createElement('p');
-                details.textContent = 'Administrator privileges are required, you will need to enter your password next.';
-                messageContainer.appendChild(details);
-                const dialog = new ConfirmDialog({
-                    title: nls.localizeByDefault('Create launcher'),
-                    msg: messageContainer,
-                    ok: Dialog.YES,
-                    cancel: Dialog.NO
-                });
-                const install = await dialog.open();
-                this.launcherService.createLauncher(!!install, uriScheme);
-                this.logger.info('Initialized application launcher.');
-            } else {
-                this.logger.info('Application launcher was already initialized.');
+        this.launcherService.getState(uriScheme).then(async state => {
+            if (state === 'up-to-date') {
+                this.logger.info('Application launcher already up to date.');
+                return;
             }
+            if (state === 'needs-silent-update') {
+                // Prior consent recorded. We still show a brief heads-up before the OS
+                // sudo prompt fires so the user knows what the password request is for.
+                const confirmed = await this.confirmLauncherUpdate(uriScheme, true);
+                if (confirmed) {
+                    await this.launcherService.createLauncher(true, uriScheme);
+                    this.logger.info('Application launcher updated to match current template.');
+                } else {
+                    this.logger.info('Application launcher update declined by user.');
+                }
+                return;
+            }
+            const messageContainer = document.createElement('div');
+            // eslint-disable-next-line max-len
+            messageContainer.textContent = nls.localizeByDefault(`Would you like to install a shell command that launches the application?\nYou will be able to run ${applicationName} from the command line by typing '${uriScheme}'.`);
+            messageContainer.setAttribute('style', 'white-space: pre-line');
+            const details = document.createElement('p');
+            details.textContent = 'Administrator privileges are required, you will need to enter your password next.';
+            messageContainer.appendChild(details);
+            const dialog = new ConfirmDialog({
+                title: nls.localizeByDefault('Create launcher'),
+                msg: messageContainer,
+                ok: Dialog.YES,
+                cancel: Dialog.NO
+            });
+            const install = await dialog.open();
+            this.launcherService.createLauncher(!!install, uriScheme);
+            this.logger.info('Initialized application launcher.');
         });
 
         this.desktopFileService.getState({ applicationName, uriScheme }).then(async state => {
@@ -88,5 +108,37 @@ export class CreateLauncherCommandContribution implements FrontendApplicationCon
             });
             this.logger.info('Created or updated .desktop file.');
         });
+    }
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(LauncherCommands.CREATE_LAUNCHER, {
+            execute: async () => {
+                const uriScheme = FrontendApplicationConfigProvider.get().electron.uriScheme;
+                const confirmed = await this.confirmLauncherUpdate(uriScheme, false);
+                if (!confirmed) {
+                    return;
+                }
+                await this.launcherService.createLauncher(true, uriScheme);
+                this.logger.info('CLI launcher created or updated via command.');
+            }
+        });
+    }
+
+    protected async confirmLauncherUpdate(uriScheme: string, isUpdate: boolean): Promise<boolean> {
+        const messageContainer = document.createElement('div');
+        messageContainer.textContent = isUpdate
+            ? `The CLI launcher at /usr/local/bin/${uriScheme} needs to be refreshed to match the current application.`
+            : `This will create or refresh the CLI launcher at /usr/local/bin/${uriScheme}.`;
+        messageContainer.setAttribute('style', 'white-space: pre-line');
+        const details = document.createElement('p');
+        details.textContent = 'Administrator privileges are required, you will be prompted for your password next.';
+        messageContainer.appendChild(details);
+        const dialog = new ConfirmDialog({
+            title: nls.localizeByDefault(isUpdate ? 'Update CLI launcher' : 'Create CLI launcher'),
+            msg: messageContainer,
+            ok: nls.localizeByDefault('Confirm'),
+            cancel: nls.localizeByDefault('Abort')
+        });
+        return !!await dialog.open();
     }
 }

--- a/theia-extensions/launcher/src/browser/create-launcher-frontend-module.ts
+++ b/theia-extensions/launcher/src/browser/create-launcher-frontend-module.ts
@@ -10,10 +10,13 @@ import { CreateLauncherCommandContribution } from './create-launcher-contributio
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { LauncherService } from './launcher-service';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { CommandContribution } from '@theia/core/lib/common';
 import { DesktopFileService } from './desktopfile-service';
 
 export default new ContainerModule(bind => {
-    bind(FrontendApplicationContribution).to(CreateLauncherCommandContribution);
+    bind(CreateLauncherCommandContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(CreateLauncherCommandContribution);
+    bind(CommandContribution).toService(CreateLauncherCommandContribution);
     bind(LauncherService).toSelf().inSingletonScope();
     bind(DesktopFileService).toSelf().inSingletonScope();
 });

--- a/theia-extensions/launcher/src/browser/launcher-service.ts
+++ b/theia-extensions/launcher/src/browser/launcher-service.ts
@@ -10,20 +10,19 @@
 import { Endpoint } from '@theia/core/lib/browser';
 import { injectable } from '@theia/core/shared/inversify';
 
+export type LauncherEndpointState = 'up-to-date' | 'needs-silent-update' | 'needs-prompt';
+
 @injectable()
 export class LauncherService {
 
-    async isInitialized(uriScheme?: string): Promise<boolean> {
-        const query = uriScheme ? `?uriScheme=${encodeURIComponent(uriScheme)}` : '';
-        const response = await fetch(new Request(`${this.endpoint()}/initialized${query}`), {
-            body: undefined,
-            method: 'GET'
-        }).then(r => r.json());
-        return !!response?.initialized;
+    async getState(uriScheme: string): Promise<LauncherEndpointState> {
+        const params = new URLSearchParams({ uriScheme });
+        const response = await fetch(new Request(`${this.endpoint()}/state?${params}`), { method: 'GET' }).then(r => r.json());
+        return response?.state ?? 'needs-prompt';
     }
 
-    async createLauncher(create: boolean, uriScheme?: string): Promise<void> {
-        fetch(new Request(`${this.endpoint()}`), {
+    async createLauncher(create: boolean, uriScheme: string): Promise<void> {
+        await fetch(new Request(`${this.endpoint()}`), {
             body: JSON.stringify({ create, uriScheme }),
             method: 'PUT',
             headers: new Headers({ 'Content-Type': 'application/json' })

--- a/theia-extensions/launcher/src/node/launcher-endpoint.ts
+++ b/theia-extensions/launcher/src/node/launcher-endpoint.ts
@@ -18,9 +18,11 @@ import * as fs from 'fs-extra';
 import URI from '@theia/core/lib/common/uri';
 import { getStorageFilePath } from './launcher-util';
 
+export type LauncherEndpointState = 'up-to-date' | 'needs-silent-update' | 'needs-prompt';
+
 interface PathEntry {
     source: string;
-    target: string;
+    target?: string;
 }
 
 @injectable()
@@ -36,30 +38,65 @@ export class TheiaLauncherServiceEndpoint implements BackendApplicationContribut
     configure(app: Application): void {
         const router = Router();
         router.put('/', (request, response) => this.createLauncher(request, response));
-        router.get('/initialized', (request, response) => this.isInitialized(request, response));
+        router.get('/state', (request, response) => this.getState(request, response));
         app.use(json());
         app.use(TheiaLauncherServiceEndpoint.PATH, router);
     }
 
-    private async isInitialized(request: Request, response: Response): Promise<void> {
-        if (!process.env.APPIMAGE) {
-            // we are not running from an AppImage, so there's nothing to initialize
-            // return true
-            response.json({ initialized: true });
+    protected async getState(request: Request, response: Response): Promise<void> {
+        const uriScheme = request.query.uriScheme;
+        if (typeof uriScheme !== 'string') {
+            response.status(400).json({ error: 'uriScheme query parameter is required' });
+            return;
         }
-        const uriScheme = (request.query.uriScheme as string) || 'theia';
-        const launcherLink = `/usr/local/bin/${uriScheme}`;
+        response.json({ state: await this.computeState(uriScheme) });
+    }
+
+    protected async computeState(uriScheme: string): Promise<LauncherEndpointState> {
+        if (!process.env.APPIMAGE) {
+            // Not running from an AppImage — nothing to install.
+            return 'up-to-date';
+        }
+        const launcher = `/usr/local/bin/${uriScheme}`;
         const storageFile = await getStorageFilePath(this.envServer, TheiaLauncherServiceEndpoint.STORAGE_FILE_NAME);
         if (!storageFile) {
             throw new Error('Could not resolve path to storage file.');
         }
-        if (!fs.existsSync(storageFile)) {
-            response.json({ initialized: false });
-            return;
-        }
         const data = await this.readLauncherPathsFromStorage(storageFile);
-        const initialized = !!data.find(entry => entry.source === launcherLink);
-        response.json({ initialized });
+        // Latest entry wins so a previous decline followed by a later approve is honored correctly.
+        const latest = [...data].reverse().find(entry => entry.source === launcher);
+        if (!latest) {
+            return 'needs-prompt';
+        }
+        if (latest.target === undefined) {
+            // Previously declined for this scheme — don't re-prompt.
+            return 'up-to-date';
+        }
+        if (latest.target !== process.env.APPIMAGE) {
+            // AppImage path changed — ask for consent again.
+            return 'needs-prompt';
+        }
+        // Prior consent recorded for this AppImage — re-apply silently if the on-disk
+        // script no longer matches what the current generator would produce.
+        const logFile = await this.getLogFilePath();
+        const expected = this.buildLauncherScript(process.env.APPIMAGE, logFile);
+        return this.fileMatches(launcher, expected) ? 'up-to-date' : 'needs-silent-update';
+    }
+
+    protected fileMatches(filePath: string, expectedContents: string): boolean {
+        try {
+            return fs.readFileSync(filePath, 'utf8') === expectedContents;
+        } catch {
+            return false;
+        }
+    }
+
+    protected buildLauncherScript(target: string, logFile: string): string {
+        // Must reproduce the exact bytes the printf-based writer in createLauncher produces.
+        // The JS template builds `\$1`, but @vscode/sudo-prompt wraps the command in
+        // `/bin/bash -c "..."`, and the outer double-quote layer consumes the backslash,
+        // so the on-disk file ends up with `$1` (no backslash). Match that here.
+        return `#!/bin/bash\nexec "${target}" $1 &> ${logFile} &\n`;
     }
 
     private async readLauncherPathsFromStorage(storageFile: string): Promise<PathEntry[]> {
@@ -81,24 +118,32 @@ export class TheiaLauncherServiceEndpoint implements BackendApplicationContribut
     }
 
     private async createLauncher(request: Request, response: Response): Promise<void> {
-        const shouldCreateLauncher = request.body.create;
-        const uriScheme: string = request.body.uriScheme || 'theia';
+        const { uriScheme } = request.body;
+        if (typeof uriScheme !== 'string') {
+            response.status(400).json({ error: 'uriScheme is required' });
+            return;
+        }
+        const shouldCreateLauncher: boolean = !!request.body.create;
         const launcher = `/usr/local/bin/${uriScheme}`;
         const sudoPromptName = uriScheme === 'theia-next' ? 'Theia IDE Next' : 'Theia IDE';
         const target = process.env.APPIMAGE;
         const logFile = await this.getLogFilePath();
-        const command = `printf '%s\n' '#!/bin/bash' 'exec "${target}" \\$1 &> ${logFile} &' >${launcher} && chmod +x ${launcher}`;
         if (shouldCreateLauncher) {
             const targetExists = target && fs.existsSync(target);
             if (!targetExists) {
                 throw new Error('Could not find application to launch');
             }
+            const command = `printf '%s\n' '#!/bin/bash' 'exec "${target}" \\$1 &> ${logFile} &' >${launcher} && chmod +x ${launcher}`;
             sudo.exec(command, { name: sudoPromptName });
         }
 
         const storageFile = await getStorageFilePath(this.envServer, TheiaLauncherServiceEndpoint.STORAGE_FILE_NAME);
         const data = fs.existsSync(storageFile) ? await this.readLauncherPathsFromStorage(storageFile) : [];
-        fs.outputJSONSync(storageFile, [...data, { source: launcher, target: shouldCreateLauncher ? target : undefined }]);
+        const filtered = data.filter(existing => existing.source !== launcher);
+        const entry: PathEntry = shouldCreateLauncher
+            ? { source: launcher, target }
+            : { source: launcher };
+        fs.outputJSONSync(storageFile, [...filtered, entry]);
 
         response.sendStatus(200);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Follow-up to #720, applying the same 3-state getState pattern (up-to-date / needs-silent-update / needs-prompt) to the CLI launcher endpoint so the `/usr/local/bin/<scheme>` script self-heals when its on-disk contents no longer match the current generator output. This closes the same gap for the CLI launcher that #720 closed for `.desktop` files.

Without this, existing installations keep their old launcher script until the user manually re-runs the Create launcher command, even after the IDE ships a new launcher script template.

- Replace `/initialized` with `/state` on the launcher endpoint, returning one of up-to-date / needs-silent-update / needs-prompt
- Add `computeState` and `isOnDiskUpToDate` to compare the on-disk script byte-for-byte against what the current generator would produce
- Honor decline-then-approve by reading the latest matching entry from `paths.json` (was returning the first match)
- De-dupe `paths.json` entries by source on write (was append-only, growing on every consent decision)
- Validate `uriScheme` on both endpoints (400 if missing), matching the desktop file endpoint
- On needs-silent-update, show a brief heads-up dialog explaining that the launcher script needs refreshing and that admin privileges are required, then trigger the sudo prompt. The dialog gives the user context the OS password prompt alone does not provide
- Add a new "Create CLI Launcher" command to the palette so declined users can opt back in at any time, instead of having to delete config files and restart. The command shows the same heads-up dialog before sudo


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The setup is identical to #720, same sandbox env vars and fake AppImage. See [#720's How to test section](https://github.com/eclipse-theia/theia-ide/pull/720) for the sandbox bootstrap (`/tmp/launchertest/...`, `APPIMAGE`, `APPDIR`, `XDG_DATA_HOME`, `THEIA_CONFIG_DIR`).

Note: the launcher writes to `/usr/local/bin/`, so a system sudo prompt is unavoidable whenever the script is created or refreshed. This PR adds a Theia-level confirmation dialog before that sudo prompt fires in the needs-silent-update and command-invoked paths so the user has context for the password request.

##### Test 1: First run prompts (needs-prompt)

1. Ensure clean state: `rm -rf /tmp/launchertest/config`
2. `yarn electron start`
3. Expect: the Create launcher dialog appears (alongside the Create .desktop file dialog from #720, both are first-time consent prompts).
4. Click Yes and enter sudo password.
5. Expect: `/usr/local/bin/<scheme>` exists, and `paths.json` has one entry with target set:

   ```bash
   cat /usr/local/bin/theia
   cat /tmp/launchertest/config/globalStorage/theia-ide-launcher/paths.json
   ```

##### Test 2: No change on restart (up-to-date)

1. Restart with the same env.
2. Expect: no dialog, log says `Application launcher already up to date.`

##### Test 3: Silent self-heal (needs-silent-update), headline feature

1. Drift the on-disk script:

   ```bash
   echo "# stale" | sudo tee -a /usr/local/bin/theia
   ```

2. Restart the app.
3. Expect: an "Update CLI launcher" dialog appears first, explaining the launcher needs refreshing and that admin privileges are required.
4. Click Confirm, then enter sudo password.
5. Expect: the file is rewritten back to the template. Log says `Application launcher updated to match current template.`. Verify:

   ```bash
   tail -n2 /usr/local/bin/theia
   ```

6. Repeat the drift step and restart again, but this time click Abort on the dialog.
7. Expect: no sudo prompt, script remains drifted, log says `Application launcher update declined by user.`

##### Test 4: New AppImage path re-prompts

1. Change APPIMAGE to a new path:

   ```bash
   touch /tmp/launchertest/Theia-IDE-v2.AppImage
   export APPIMAGE=/tmp/launchertest/Theia-IDE-v2.AppImage
   yarn electron start
   ```

2. Expect: the Create launcher consent dialog appears again (stored target does not match current APPIMAGE).

##### Test 5: Decline is remembered

1. Clean state: `rm -rf /tmp/launchertest/config/*`
2. Start the app, dialog appears, click No.
3. Expect: `paths.json` has one entry with no target field, no file at `/usr/local/bin/<scheme>`:

   ```bash
   cat /tmp/launchertest/config/globalStorage/theia-ide-launcher/paths.json
   ```

4. Restart with the same env.
5. Expect: no dialog (declined is treated as up-to-date).

##### Test 6: Decline followed by later approve via command palette

1. Clean state, decline once (Test 5 step 2).
2. Open the command palette and run "Create CLI Launcher" (this PR adds the palette entry so declined users have a way to opt back in).
3. Expect: a "Create CLI launcher" dialog appears explaining what will happen and that admin privileges are required.
4. Click Confirm, then enter sudo password.
5. Expect: `paths.json` has one entry (de-duped) with target set, `/usr/local/bin/<scheme>` exists.
6. Restart, no dialog, up-to-date.

##### Cleanup

```bash
rm -rf /tmp/launchertest
sudo rm -f /usr/local/bin/theia /usr/local/bin/theia-next
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

