### PR TITLE
fix(launcher): forward all CLI args and support --help/--version

### DIFF
--- a/applications/electron-next/scripts/cli-usage.js
+++ b/applications/electron-next/scripts/cli-usage.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+
+/**
+ * Checks whether any of the given flags is present in process.argv,
+ * stopping at the `--` separator (everything after `--` is treated as data).
+ * @param flags - The flags to look for (e.g. ['--version', '-v'])
+ * @returns true if any of the flags is present before a `--` separator
+ */
+function hasFlag(flags) {
+    for (let i = 1; i < process.argv.length; i++) {
+        const arg = process.argv[i];
+        if (arg === '--') {
+            return false;
+        }
+        if (flags.includes(arg)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Handles --version/-v and --help early, before loading the full electron stack,
+ * and exits the process if either flag is present.
+ *
+ * The upstream ElectronMainApplication uses yargs without setting .version()
+ * and with .help(false), so these flags don't work in bundled/AppImage contexts.
+ *
+ * @param packageJsonPath - Path to the application's package.json
+ */
+function handleVersionAndHelp(packageJsonPath) {
+    if (hasFlag(['--version', '-v'])) {
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+        console.log(packageJson.version);
+        process.exit(0);
+    }
+    if (hasFlag(['--help'])) {
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+        console.log(`${packageJson.productName} ${packageJson.version}
+
+Usage: ${packageJson.productName} [options] [file-or-folder]
+
+Options:
+  -v, --version                       Print version
+  --help                              Print usage
+
+  --electronUserData <dir>            Set the Electron user data directory
+                                      (default: platform user-data dir, e.g.
+                                      ~/.config/${packageJson.productName} on Linux)
+  --no-cluster                        Run backend in the same process
+
+  --log-level <level>                 Set log level: info, debug, warn, error,
+                                      trace, fatal (default: info)
+  --log-config <path>                 Path to a JSON log configuration file
+                                      (mutually exclusive with --log-level)
+  --log-file <path>                   Path to the log file`);
+        process.exit(0);
+    }
+}
+
+module.exports = {
+    hasFlag,
+    handleVersionAndHelp,
+};

--- a/applications/electron-next/scripts/theia-electron-main.js
+++ b/applications/electron-next/scripts/theia-electron-main.js
@@ -2,6 +2,11 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const { copyBundledPlugins } = require('./appimage-helpers');
+const { handleVersionAndHelp } = require('./cli-usage');
+
+// Handle --version and --help early, before loading the full electron stack.
+const packageJsonPath = path.resolve(__dirname, '../', 'package.json');
+handleVersionAndHelp(packageJsonPath);
 
 // Update to override the supported VS Code API version.
 // process.env.VSCODE_API_VERSION = '1.50.0'
@@ -21,7 +26,6 @@ if (isAppImage) {
     // The AppImage mount point (/tmp/.mount_*) is read-only
     const configDir = process.env.THEIA_CONFIG_DIR || path.join(os.homedir(), '.theia-ide-next');
     const userPluginsDir = path.join(configDir, 'builtInPlugins');
-    const packageJsonPath = path.resolve(__dirname, '../', 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
     const currentVersion = packageJson.version;
 

--- a/applications/electron/scripts/cli-usage.js
+++ b/applications/electron/scripts/cli-usage.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+
+/**
+ * Checks whether any of the given flags is present in process.argv,
+ * stopping at the `--` separator (everything after `--` is treated as data).
+ * @param flags - The flags to look for (e.g. ['--version', '-v'])
+ * @returns true if any of the flags is present before a `--` separator
+ */
+function hasFlag(flags) {
+    for (let i = 1; i < process.argv.length; i++) {
+        const arg = process.argv[i];
+        if (arg === '--') {
+            return false;
+        }
+        if (flags.includes(arg)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Handles --version/-v and --help early, before loading the full electron stack,
+ * and exits the process if either flag is present.
+ *
+ * The upstream ElectronMainApplication uses yargs without setting .version()
+ * and with .help(false), so these flags don't work in bundled/AppImage contexts.
+ *
+ * @param packageJsonPath - Path to the application's package.json
+ */
+function handleVersionAndHelp(packageJsonPath) {
+    if (hasFlag(['--version', '-v'])) {
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+        console.log(packageJson.version);
+        process.exit(0);
+    }
+    if (hasFlag(['--help'])) {
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+        console.log(`${packageJson.productName} ${packageJson.version}
+
+Usage: ${packageJson.productName} [options] [file-or-folder]
+
+Options:
+  -v, --version                       Print version
+  --help                              Print usage
+
+  --electronUserData <dir>            Set the Electron user data directory
+                                      (default: platform user-data dir, e.g.
+                                      ~/.config/${packageJson.productName} on Linux)
+  --no-cluster                        Run backend in the same process
+
+  --log-level <level>                 Set log level: info, debug, warn, error,
+                                      trace, fatal (default: info)
+  --log-config <path>                 Path to a JSON log configuration file
+                                      (mutually exclusive with --log-level)
+  --log-file <path>                   Path to the log file`);
+        process.exit(0);
+    }
+}
+
+module.exports = {
+    hasFlag,
+    handleVersionAndHelp,
+};

--- a/applications/electron/scripts/theia-electron-main.js
+++ b/applications/electron/scripts/theia-electron-main.js
@@ -2,6 +2,11 @@ const path = require('path');
 const fs = require('fs');
 const os = require('os');
 const { copyBundledPlugins } = require('./appimage-helpers');
+const { handleVersionAndHelp } = require('./cli-usage');
+
+// Handle --version and --help early, before loading the full electron stack.
+const packageJsonPath = path.resolve(__dirname, '../', 'package.json');
+handleVersionAndHelp(packageJsonPath);
 
 // Update to override the supported VS Code API version.
 // process.env.VSCODE_API_VERSION = '1.50.0'
@@ -21,7 +26,6 @@ if (isAppImage) {
     // The AppImage mount point (/tmp/.mount_*) is read-only
     const configDir = process.env.THEIA_CONFIG_DIR || path.join(os.homedir(), '.theia-ide');
     const userPluginsDir = path.join(configDir, 'builtInPlugins');
-    const packageJsonPath = path.resolve(__dirname, '../', 'package.json');
     const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
     const currentVersion = packageJson.version;
 

--- a/theia-extensions/launcher/src/node/launcher-endpoint.ts
+++ b/theia-extensions/launcher/src/node/launcher-endpoint.ts
@@ -15,6 +15,8 @@ import { ILogger } from '@theia/core/lib/common';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import * as sudo from '@vscode/sudo-prompt';
 import * as fs from 'fs-extra';
+import * as os from 'os';
+import * as path from 'path';
 import URI from '@theia/core/lib/common/uri';
 import { getStorageFilePath } from './launcher-util';
 
@@ -91,12 +93,28 @@ export class TheiaLauncherServiceEndpoint implements BackendApplicationContribut
         }
     }
 
+    // The normal launch path backgrounds the process and redirects to a log file,
+    // which would swallow --help / --version output. Detect those flags up front
+    // and exec without redirect so the text reaches the user's terminal.
+    // setsid -f forks the AppImage into a new session, fully detached from the
+    // terminal — so closing the terminal does not prompt about a still-running
+    // process and SIGHUP cannot reach the IDE.
     protected buildLauncherScript(target: string, logFile: string): string {
-        // Must reproduce the exact bytes the printf-based writer in createLauncher produces.
-        // The JS template builds `\$1`, but @vscode/sudo-prompt wraps the command in
-        // `/bin/bash -c "..."`, and the outer double-quote layer consumes the backslash,
-        // so the on-disk file ends up with `$1` (no backslash). Match that here.
-        return `#!/bin/bash\nexec "${target}" $1 &> ${logFile} &\n`;
+        const t = this.bashQuote(target);
+        const l = this.bashQuote(logFile);
+        return `#!/bin/bash
+for arg in "$@"; do
+    case "$arg" in
+        --) break ;;
+        --help|--version|-v) exec ${t} "$@" ;;
+    esac
+done
+setsid -f ${t} "$@" >> ${l} 2>&1 < /dev/null
+`;
+    }
+
+    private bashQuote(s: string): string {
+        return '"' + s.replace(/(["\\$`])/g, '\\$1') + '"';
     }
 
     private async readLauncherPathsFromStorage(storageFile: string): Promise<PathEntry[]> {
@@ -133,8 +151,13 @@ export class TheiaLauncherServiceEndpoint implements BackendApplicationContribut
             if (!targetExists) {
                 throw new Error('Could not find application to launch');
             }
-            const command = `printf '%s\n' '#!/bin/bash' 'exec "${target}" \\$1 &> ${logFile} &' >${launcher} && chmod +x ${launcher}`;
-            sudo.exec(command, { name: sudoPromptName });
+            const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'theia-launcher-'));
+            const tmpFile = path.join(tmpDir, path.basename(launcher));
+            fs.writeFileSync(tmpFile, this.buildLauncherScript(target!, logFile), { mode: 0o755 });
+            const command = `mv ${this.bashQuote(tmpFile)} ${this.bashQuote(launcher)} && chmod 755 ${this.bashQuote(launcher)}`;
+            sudo.exec(command, { name: sudoPromptName }, () => {
+                try { fs.removeSync(tmpDir); } catch { /* best effort */ }
+            });
         }
 
         const storageFile = await getStorageFilePath(this.envServer, TheiaLauncherServiceEndpoint.STORAGE_FILE_NAME);


### PR DESCRIPTION
#### What it does

> Stacked on #727. With both PRs applied, existing installations with the old `$1` script automatically hit #727's `needs-silent-update` path on next IDE start (the on-disk script no longer matches what `buildLauncherScript` produces) and refresh themselves with only a sudo prompt.

Fixes the `theia` shell launcher (`/usr/local/bin/<scheme>`) installed by the "Create launcher" flow.

- Forward all CLI args by replacing `$1` with `"$@"`. The generated script previously used `exec "<AppImage>" $1 &> ...`, so anything beyond the first arg was silently dropped (`theia /a /b` only opened `/a`, `theia /path --log-level=debug` dropped the flag).
- Generate the script via a tempfile and `sudo mv` instead of escaping `printf` through multiple shell layers. The previous approach was fragile: surviving sudo-prompt's `bash -c "..."` double-quote wrap is easy to get wrong, and an earlier `"$@"` attempt actually expanded to `""` through that layer. The script content is now built as a Node string, written to `os.tmpdir()`, then sudo only does `mv + chmod`.
- Surface `--help`, `--version`, and `-v`, in two layers:
  - In the generated launcher, detect the flags up front and skip the background+log redirect so output reaches stdout instead of `~/.theia-ide/logs/launcher.log`.
  - In `applications/electron{,-next}/scripts/theia-electron-main.js`, intercept the flags before the Electron stack loads, because upstream `ElectronMainApplication` uses yargs with `.help(false)` and no `.version()`. A per-arg scan stops at `--` so paths like `./foo/--help` don't spuriously trigger help mode.
- Restrict the help text to flags actually consumed by the Electron launcher: `--electronUserData`, `--no-cluster`, `--log-level`, `--log-config`, `--log-file`. Removed misleading entries (`list-plugins`, `--install-plugin`, `--port`, `--hostname`, `--plugins`) that are backend `CliContribution`s and silently no-op when routed through the Electron main process. Defaults are shown where meaningful (`--log-level` defaults to `info`, `--electronUserData` defaults to the platform user-data dir), and `--log-config` is annotated as mutually exclusive with `--log-level`.
- Append (`&>>`) instead of clobber (`&>`) the launcher log so it grows across sessions.
- Use `setsid -f` instead of `&` to fully detach the AppImage into its own session. Closing the terminal that ran `theia` no longer warns about a still-running process, and SIGHUP from terminal close cannot kill the IDE. The old `$1` script had the same problem.

##### Follow-ups (out of scope, tracked separately)

- VS Code style "open file in current window" for `theia /some/file.txt`. Needs an upstream change in `@theia/core`'s `ElectronMainApplication` and `@theia/workspace` (the frontend currently rejects non-folder, non-`.theia-workspace` paths with "Not a valid workspace file").
- `-g file:line:column` VS Code parity. Needs an upstream change.
- CLI shim installation on Mac (a `code`-style `/usr/local/bin/...` symlink) and Windows (an "Add to PATH" installer option). Currently Linux AppImage only.

#### How to test

End-to-end test against the real `/usr/local/bin/theia-next` CLI launcher. All steps use `applications/electron-next` (Theia IDE Next) so they don't touch your daily-driver `/usr/local/bin/theia`. The same flow works against `applications/electron` if you also want to verify Theia IDE.

> Heads up: this overwrites `/usr/local/bin/theia-next` on your system via sudo. See the "Restore" section at the end if you want to roll back afterwards.

##### Setup, build and install the new launcher

```bash
yarn && yarn build
cd applications/electron-next && yarn package
./dist/*.AppImage
```

When the AppImage starts, one of two dialogs or prompts fires:
- If you already have an old `/usr/local/bin/theia-next`, no Theia dialog appears. A system sudo prompt fires (#727's `needs-silent-update` path detected the drift) and the script is rewritten in place.
- If you have no prior launcher, the "Create launcher" dialog appears. Click Yes and enter your sudo password.

Verify the new script:

```bash
cat /usr/local/bin/theia-next
```

Expected:
```bash
#!/bin/bash
for arg in "$@"; do
    case "$arg" in
        --) break ;;
        --help|--version|-v) exec "/path/to/Theia-IDE-Next.AppImage" "$@" ;;
    esac
done
setsid -f "/path/to/Theia-IDE-Next.AppImage" "$@" >> "/home/<user>/.theia-ide-next/logs/launcher.log" 2>&1 < /dev/null
```

##### Test 1: `--help`, `--version`, `-v` reach the terminal

```bash
theia-next --help        # prints usage to stdout, no GUI
theia-next --version     # prints version
theia-next -v            # same
```

Verify the help text lists only the flags this PR documents (no `list-plugins`, no `--install-plugin`, etc.) and that defaults are shown for `--log-level` and `--electronUserData`.

##### Test 2: Single-arg forwarding (regression check)

```bash
theia-next .
```

Opens the current folder as workspace.

##### Test 3: Multi-arg forwarding (headline fix)

```bash
theia-next /some/folder --log-level=debug
```

Confirm the log level is honored (debug entries in the latest `~/.theia-ide-next/logs/*.log`).

##### Test 4: Second-instance focus (regression check)

1. Start: `theia-next .`
2. From another terminal: `theia-next /some/other/folder`
3. The running instance comes to the foreground and a new window opens with `/some/other/folder`.

##### Test 5: Log appends across sessions

```bash
ls -l ~/.theia-ide-next/logs/launcher.log   # note size
theia-next /folder                          # close window after it opens
ls -l ~/.theia-ide-next/logs/launcher.log   # size grew, not reset
```

##### Test 6: Process detaches from the terminal

```bash
theia-next .
# Confirm the AppImage runs in its own session, fully detached from the shell:
ps -o pid,ppid,sid,tty,comm -p "$(pgrep -f TheiaIDENext | head -1)"
# Expected: SID is different from this shell's SID, TT shows '?' (no controlling tty).
```

Try closing the terminal window. No "still a process running" warning should appear, and the IDE keeps running.

##### Restore

To roll back to a previous launcher script after testing:

```bash
sudo rm /usr/local/bin/theia-next
rm ~/.theia-ide-next/globalStorage/theia-ide-launcher/paths.json
# Then re-run an older AppImage (or this one) to recreate via the Create launcher dialog.
```

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
