### PR TITLE
chore(license-check): move dash-licenses workaround into a local script

### DIFF
--- a/.github/workflows/license-check-workflow.yml
+++ b/.github/workflows/license-check-workflow.yml
@@ -51,12 +51,6 @@ jobs:
         shell: bash
         run: |
           yarn --frozen-lockfile --ignore-scripts
-          # Workaround: pre-download dash-licenses JAR (see comments in step below)
-          DASH_JAR="node_modules/@eclipse-dash/nodejs-wrapper/download/dash-licenses.jar"
-          mkdir -p "$(dirname "$DASH_JAR")"
-          SNAP_BASE="https://repo.eclipse.org/repository/dash-maven2-snapshots/org/eclipse/dash/org.eclipse.dash.licenses/1.1.1-SNAPSHOT"
-          SNAP_JAR=$(curl -s "$SNAP_BASE/maven-metadata.xml" | grep -oP '(?<=<value>)1\.1\.1-[^<]+' | tail -1)
-          curl -L "$SNAP_BASE/org.eclipse.dash.licenses-$SNAP_JAR.jar" -o "$DASH_JAR"
           yarn license:check
 
       - name: Run dash-licenses check in review mode
@@ -64,18 +58,6 @@ jobs:
         shell: bash
         run: |
           yarn --frozen-lockfile --ignore-scripts
-          # Workaround: pre-download dash-licenses JAR since the @eclipse-dash/nodejs-wrapper
-          # uses a broken Nexus 2 URL after the repo.eclipse.org upgrade to Nexus 3.
-          # We use 1.1.1-SNAPSHOT because 1.0.2 and 1.1.0 incorrectly flag internal
-          # workspace packages (link:true with no version) as restricted.
-          # See: https://github.com/eclipse-dash/nodejs-wrapper/issues/7
-          # See: https://github.com/eclipse-dash/dash-licenses/issues/534
-          # TODO: remove this workaround once the nodejs-wrapper is updated (GH-17168)
-          DASH_JAR="node_modules/@eclipse-dash/nodejs-wrapper/download/dash-licenses.jar"
-          mkdir -p "$(dirname "$DASH_JAR")"
-          SNAP_BASE="https://repo.eclipse.org/repository/dash-maven2-snapshots/org/eclipse/dash/org.eclipse.dash.licenses/1.1.1-SNAPSHOT"
-          SNAP_JAR=$(curl -s "$SNAP_BASE/maven-metadata.xml" | grep -oP '(?<=<value>)1\.1\.1-[^<]+' | tail -1)
-          curl -L "$SNAP_BASE/org.eclipse.dash.licenses-$SNAP_JAR.jar" -o "$DASH_JAR"
           yarn license:check:review
         env:
           DASH_TOKEN: ${{ secrets.DASH_LICENSES_PAT }}

--- a/package.json
+++ b/package.json
@@ -60,8 +60,9 @@
     "update:next": "ts-node scripts/update-theia-version.ts next && lerna run update:next",
     "lint": "eslint --ext js,jsx,ts,tsx scripts && lerna run lint",
     "lint:fix": "eslint --ext js,jsx,ts,tsx scripts --fix && lerna run lint:fix",
-    "license:check": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json",
-    "license:check:review": "npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json --review",
+    "license:check:fetch-jar": "node scripts/fetch-dash-licenses-jar.js",
+    "license:check": "yarn license:check:fetch-jar && npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json",
+    "license:check:review": "yarn license:check:fetch-jar && npx dash-licenses-wrapper  --configFile=./configs/license-check-config.json --review",
     "postinstall": "theia-patch && npx patch-package --patch-dir patches"
   },
   "theiaPluginsDir": "plugins",

--- a/scripts/fetch-dash-licenses-jar.js
+++ b/scripts/fetch-dash-licenses-jar.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// @ts-check
+
+/**
+ * Pre-download the dash-licenses JAR into the location expected by
+ * @eclipse-dash/nodejs-wrapper.
+ *
+ * The wrapper's built-in downloader points at a Nexus 2 URL that no longer
+ * resolves after repo.eclipse.org's Nexus 3 upgrade, so we fetch the JAR
+ * ourselves from the Nexus 3 snapshots repo. We pin to 1.1.1-SNAPSHOT because
+ * 1.0.2 / 1.1.0 misclassify workspace packages (link:true with no version) as
+ * restricted.
+ *
+ * See:
+ *   - https://github.com/eclipse-dash/nodejs-wrapper/issues/7
+ *   - https://github.com/eclipse-dash/dash-licenses/issues/534
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SNAPSHOT_BASE =
+    'https://repo.eclipse.org/repository/dash-maven2-snapshots/org/eclipse/dash/org.eclipse.dash.licenses/1.1.1-SNAPSHOT';
+const JAR_PATH = path.resolve(
+    __dirname,
+    '..',
+    'node_modules/@eclipse-dash/nodejs-wrapper/download/dash-licenses.jar'
+);
+
+main().catch(err => {
+    console.error(err);
+    process.exit(1);
+});
+
+async function main() {
+    if (fs.existsSync(JAR_PATH) && fs.statSync(JAR_PATH).size > 1_000_000) {
+        console.info(`dash-licenses JAR already present at ${JAR_PATH}`);
+        return;
+    }
+    fs.mkdirSync(path.dirname(JAR_PATH), { recursive: true });
+    const metadata = (await httpGet(`${SNAPSHOT_BASE}/maven-metadata.xml`)).toString('utf8');
+    const versions = [...metadata.matchAll(/<value>(1\.1\.1-[^<]+)<\/value>/g)].map(m => m[1]);
+    if (versions.length === 0) {
+        throw new Error('Could not resolve dash-licenses snapshot version from maven-metadata.xml');
+    }
+    const version = versions[versions.length - 1];
+    console.info(`Downloading dash-licenses ${version}...`);
+    const jar = await httpGet(`${SNAPSHOT_BASE}/org.eclipse.dash.licenses-${version}.jar`);
+    if (jar.length < 1_000_000) {
+        throw new Error(`Downloaded JAR looks invalid (${jar.length} bytes)`);
+    }
+    fs.writeFileSync(JAR_PATH, jar);
+    console.info(`Wrote ${JAR_PATH} (${jar.length} bytes)`);
+}
+
+/**
+ * @param {string} url
+ * @returns {Promise<Buffer>}
+ */
+function httpGet(url, redirects = 5) {
+    return new Promise((resolve, reject) => {
+        const lib = url.startsWith('https:') ? require('https') : require('http');
+        lib.get(url, res => {
+            if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+                if (redirects <= 0) {
+                    reject(new Error(`Too many redirects fetching ${url}`));
+                    return;
+                }
+                res.resume();
+                resolve(httpGet(new URL(res.headers.location, url).toString(), redirects - 1));
+                return;
+            }
+            if (res.statusCode !== 200) {
+                reject(new Error(`GET ${url} failed: HTTP ${res.statusCode}`));
+                res.resume();
+                return;
+            }
+            const chunks = [];
+            res.on('data', chunk => chunks.push(chunk));
+            res.on('end', () => resolve(Buffer.concat(chunks)));
+            res.on('error', reject);
+        }).on('error', reject);
+    });
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Pre-download the dash-licenses JAR via a local Node script so the @eclipse-dash/nodejs-wrapper Nexus 2 URL workaround also applies to local runs, not just CI.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- `rm -rf node_modules`
- `yarn`
- `yarn license:check` and verify the jar was download and license check runs as expected

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

