### PR TITLE
fix: build local Theia robustly from any path

### DIFF
--- a/docs/developing-with-local-theia.md
+++ b/docs/developing-with-local-theia.md
@@ -23,7 +23,7 @@ This matches the script's default `--theia-path` of `../theia`. You can clone Th
 
 ## Important Note
 
-This script does not update the IDE version or Theia package versions in `package.json` files. It uses the current state of both repositories and relies on yarn linking to override the dependencies. If needed, you can run versioning commands (e.g., `yarn update:theia <version>`) separately before building.
+This script does not update the IDE version or Theia package versions in `package.json` files. It uses the current state of both repositories and symlinks the local `@theia/*` packages into the IDE's `node_modules` to override the dependencies. If needed, you can run versioning commands (e.g., `yarn update:theia <version>`) separately before building.
 
 ## Quick Start
 
@@ -31,30 +31,46 @@ This script does not update the IDE version or Theia package versions in `packag
 # Clone Theia as a sibling (if not already done)
 git clone https://github.com/eclipse-theia/theia.git ../theia
 
-# Build everything
-node scripts/build-with-local-theia.js
+# Build everything (default location ../theia)
+yarn build:local-theia
+```
+
+`yarn build:local-theia` is a convenience wrapper for the default setup. It is
+equivalent to running `node scripts/build-with-local-theia.js` directly.
+
+Any options are forwarded to the script, so the two forms below are equivalent:
+
+```sh
+yarn build:local-theia --theia-path /path/to/theia --package
+node scripts/build-with-local-theia.js --theia-path /path/to/theia --package
 ```
 
 ## What the Script Does
 
 1. Build the local Theia framework (`npm ci` + `npm run compile`)
-2. Create yarn links for all `@theia/*` packages
-3. Link those packages into the Theia IDE
-4. Build the Theia IDE extensions and electron-next application
-5. Download required plugins
+2. Install the IDE dependencies (`yarn`)
+3. Symlink all `@theia/*` packages from the local Theia into the IDE's `node_modules`, pointing at the given `--theia-path`
+4. Copy any transitive dependencies that the linked packages need but cannot resolve from the Theia checkout (see [Why some dependencies are copied](#why-some-dependencies-are-copied))
+5. Build the Theia IDE extensions and electron-next application
+6. Download required plugins
+
+The symlinks point explicitly at the requested `--theia-path`, so the build always uses that exact checkout. This works with Theia cloned in any location, including git worktrees.
 
 ## Usage
 
 ### Full Build
 
 ```sh
-node scripts/build-with-local-theia.js
+yarn build:local-theia
 ```
 
 ### Using a Different Theia Location
 
+Theia can live anywhere; pass its path with `--theia-path`. This also works with
+git worktrees, since the packages are symlinked at the exact path you provide:
+
 ```sh
-node scripts/build-with-local-theia.js --theia-path /path/to/theia
+yarn build:local-theia --theia-path /path/to/theia
 ```
 
 ### Incremental Development
@@ -63,7 +79,7 @@ After the initial build, you can iterate faster:
 
 ```sh
 # Rebuild only Theia IDE (Theia unchanged)
-node scripts/build-with-local-theia.js --skip-theia-build
+yarn build:local-theia --skip-theia-build
 
 # Rebuild only Theia packages, then rebuild Theia IDE
 cd ../theia && npm run compile
@@ -75,7 +91,7 @@ cd ../theia-ide && yarn build:applications:next:dev
 To create a distributable application:
 
 ```sh
-node scripts/build-with-local-theia.js --package
+yarn build:local-theia --package
 ```
 
 The packaged application will be in `applications/electron-next/dist/`.
@@ -85,7 +101,7 @@ The packaged application will be in `applications/electron-next/dist/`.
 If you want to manage builds manually:
 
 ```sh
-node scripts/build-with-local-theia.js --skip-theia-build --skip-ide-build
+yarn build:local-theia --skip-theia-build --skip-ide-build
 ```
 
 ### Skip Plugin Download
@@ -93,7 +109,7 @@ node scripts/build-with-local-theia.js --skip-theia-build --skip-ide-build
 If you already have plugins or want to skip downloading them:
 
 ```sh
-node scripts/build-with-local-theia.js --skip-plugins
+yarn build:local-theia --skip-plugins
 ```
 
 ### Restore Normal Dependencies
@@ -101,17 +117,17 @@ node scripts/build-with-local-theia.js --skip-plugins
 When you're done testing with the local Theia:
 
 ```sh
-node scripts/build-with-local-theia.js --unlink
+yarn build:local-theia --unlink
 ```
 
-This removes all yarn links and reinstalls packages from npm.
+This removes the `@theia/*` symlinks and reinstalls packages from npm.
 
 ### Dry Run
 
 Preview what commands will be executed:
 
 ```sh
-node scripts/build-with-local-theia.js --dry-run
+yarn build:local-theia --dry-run
 ```
 
 ## Running the Theia IDE (Next)
@@ -132,7 +148,7 @@ A typical development workflow looks like:
 
     ```sh
     git clone https://github.com/eclipse-theia/theia.git ../theia
-    node scripts/build-with-local-theia.js
+    yarn build:local-theia
     ```
 
 2. **Make changes in Theia**: Edit files in `../theia`
@@ -154,7 +170,7 @@ A typical development workflow looks like:
 5. **When done**: Restore npm dependencies
 
     ```sh
-    node scripts/build-with-local-theia.js --unlink
+    yarn build:local-theia --unlink
     ```
 
 ## Command Reference
@@ -170,6 +186,25 @@ A typical development workflow looks like:
 | `--dry-run`           | Print commands without executing them                |
 | `--help`              | Show help message                                    |
 
+## Why some dependencies are copied
+
+When the local Theia is installed with `npm`, some transitive dependencies end
+up nested inside a package's own `node_modules` (for example
+`packages/filesystem/node_modules/tar-stream`). Such a nested package may rely
+on a dependency (e.g. `b4a`) that is not installed anywhere reachable from the
+Theia checkout. Because the build bundler and the packager resolve modules
+starting from the symlinked location, they would fail with errors like:
+
+```text
+✘ [ERROR] Could not resolve "b4a"
+    ../../../theia/packages/filesystem/node_modules/tar-stream/pack.js
+```
+
+To avoid this, the script scans the linked packages for dependencies that
+cannot be resolved from the Theia checkout and copies them from the IDE's own
+`node_modules` into the Theia checkout's `node_modules`. This is generic over
+the dependency name and runs during both the build and the packaging step.
+
 ## Troubleshooting
 
 ### "Theia directory not found"
@@ -183,7 +218,7 @@ git clone https://github.com/eclipse-theia/theia.git ../theia
 Or specify the correct path:
 
 ```sh
-node scripts/build-with-local-theia.js --theia-path /correct/path/to/theia
+yarn build:local-theia --theia-path /correct/path/to/theia
 ```
 
 ### "Package not found in local Theia"
@@ -202,7 +237,7 @@ If you switch branches in either repository, clean and rebuild:
 ```sh
 # In theia-ide
 git clean -xfd
-node scripts/build-with-local-theia.js
+yarn build:local-theia
 
 # Or if only Theia packages changed
 cd ../theia && git clean -xfd && npm ci && npm run compile
@@ -215,7 +250,7 @@ If things get into a bad state:
 
 ```sh
 # Unlink and restore npm packages
-node scripts/build-with-local-theia.js --unlink
+yarn build:local-theia --unlink
 
 # Full clean rebuild
 git clean -xfd

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "build:applications:next": "lerna run --scope=\"theia-ide-next*\" build:prod --concurrency 1",
     "build:applications:next:dev": "lerna run --scope=\"theia-ide-next*\" build --concurrency 1",
     "build:extensions": "lerna run --scope=\"theia-ide*ext\" build",
+    "build:local-theia": "node scripts/build-with-local-theia.js",
     "download:plugins": "theia download:plugins --rate-limit=15 --parallel=false && yarn permissions:writeable",
     "package:applications": "lerna run --scope=\"theia-ide*app\" --ignore=\"theia-ide-next*\" package --concurrency 1",
     "package:applications:preview": "lerna run --scope=\"theia-ide*app\" --ignore=\"theia-ide-next*\" package:preview --concurrency 1",

--- a/scripts/build-with-local-theia.js
+++ b/scripts/build-with-local-theia.js
@@ -60,7 +60,9 @@ Usage: node scripts/build-with-local-theia.js [options]
 This script builds the Theia IDE against a local Theia framework checkout,
 allowing you to test framework changes without publishing to npm first.
 
-The script uses yarn link to connect the local Theia packages to the IDE build.
+The script symlinks the local Theia packages into the IDE's node_modules,
+pointing explicitly at the given --theia-path (works with any location,
+including git worktrees).
 
 Note: This script does not update the IDE version or Theia package versions.
 It uses the current state of both repositories. If needed, you can run
@@ -210,11 +212,23 @@ function buildTheia() {
 }
 
 /**
- * Create yarn link for Theia packages
+ * Path of a Theia package inside the IDE's node_modules, e.g.
+ * node_modules/@theia/core.
+ */
+function idePackagePath(dep) {
+    return path.join(ROOT_DIR, 'node_modules', ...dep.split('/'));
+}
+
+/**
+ * Create direct symlinks from the IDE's node_modules to the local Theia
+ * packages. Symlinks point explicitly at the requested --theia-path, so the
+ * build always resolves against that checkout. This avoids yarn's global link
+ * registry, which is keyed by package name and silently keeps pointing at a
+ * previously linked path (e.g. the default ../theia) instead of a worktree.
  */
 function linkTheiaPackages() {
     console.log(`\n${'='.repeat(60)}`);
-    console.log('> Creating yarn links for Theia packages');
+    console.log('> Linking local Theia packages into the IDE');
     console.log(`${'='.repeat(60)}\n`);
 
     const theiaPackages = findTheiaPackages(options.theiaPath);
@@ -226,26 +240,27 @@ function linkTheiaPackages() {
     const linked = [];
     const missing = [];
 
-    // Create links in Theia packages
     for (const dep of requiredDeps) {
-        const pkgPath = theiaPackages.get(dep);
-        if (pkgPath) {
-            if (!options.dryRun) {
-                console.log(`Linking ${dep}...`);
-                try {
-                    execSync('yarn link', { cwd: pkgPath, stdio: 'pipe' });
-                } catch (e) {
-                    // Link might already exist, that's fine
-                }
-            }
-            linked.push(dep);
-        } else {
+        const target = theiaPackages.get(dep);
+        if (!target) {
             missing.push(dep);
+            continue;
         }
-    }
-
-    if (options.dryRun) {
-        console.log(`Would create yarn links for ${linked.length} packages`);
+        const linkPath = idePackagePath(dep);
+        if (options.dryRun) {
+            console.log(`[DRY RUN] Would link ${dep} -> ${target}`);
+            linked.push(dep);
+            continue;
+        }
+        // Replace whatever is there (npm-installed package or stale symlink)
+        // with a fresh symlink to the requested checkout.
+        fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+        fs.rmSync(linkPath, { recursive: true, force: true });
+        // 'junction' is used for cross-platform directory links: on Windows it
+        // avoids the admin requirement of symlinks, on POSIX the type is ignored.
+        fs.symlinkSync(target, linkPath, 'junction');
+        console.log(`Linked ${dep} -> ${target}`);
+        linked.push(dep);
     }
 
     if (missing.length > 0) {
@@ -253,43 +268,36 @@ function linkTheiaPackages() {
         missing.forEach(m => console.log(`  - ${m}`));
     }
 
-    // Link packages in IDE
-    console.log(`\nLinking ${linked.length} packages in IDE...`);
-    if (linked.length > 0) {
-        const linkCmd = `yarn link ${linked.join(' ')}`;
-        console.log(`$ ${linkCmd}`);
-        if (!options.dryRun) {
-            execSync(linkCmd, { cwd: ROOT_DIR, stdio: 'inherit' });
-        } else {
-            console.log('[DRY RUN] Command not executed');
-        }
-    }
-
     console.log(`\n${options.dryRun ? 'Would link' : 'Linked'} ${linked.length} packages`);
     return linked;
 }
 
 /**
- * Unlink Theia packages and restore npm dependencies
+ * Remove the symlinks created by linkTheiaPackages and restore npm versions.
  */
 function unlinkTheiaPackages() {
     console.log(`\n${'='.repeat(60)}`);
-    console.log('> Removing yarn links and restoring npm dependencies');
+    console.log('> Removing Theia package links and restoring npm dependencies');
     console.log(`${'='.repeat(60)}\n`);
 
     const requiredDeps = collectAllTheiaDependencies();
 
-    // Unlink packages
-    if (options.dryRun) {
-        console.log(`Would unlink ${requiredDeps.size} packages`);
-    } else {
-        for (const dep of requiredDeps) {
-            console.log(`Unlinking ${dep}...`);
-            try {
-                execSync(`yarn unlink ${dep}`, { cwd: ROOT_DIR, stdio: 'pipe' });
-            } catch (e) {
-                // Ignore errors if not linked
-            }
+    for (const dep of requiredDeps) {
+        const linkPath = idePackagePath(dep);
+        let isSymlink = false;
+        try {
+            isSymlink = fs.lstatSync(linkPath).isSymbolicLink();
+        } catch {
+            // not present, nothing to remove
+        }
+        if (!isSymlink) {
+            continue;
+        }
+        if (options.dryRun) {
+            console.log(`[DRY RUN] Would remove link ${dep}`);
+        } else {
+            fs.rmSync(linkPath, { recursive: true, force: true });
+            console.log(`Removed link ${dep}`);
         }
     }
 
@@ -303,8 +311,11 @@ function unlinkTheiaPackages() {
  * Build IDE
  */
 function buildIde() {
+    // Install first: yarn install replaces node_modules/@theia/* with the
+    // registry versions, so the local packages must be linked afterwards.
     run('yarn', ROOT_DIR, 'Install IDE dependencies');
-    // sync must run after yarn install so missing transitives are present
+    linkTheiaPackages();
+    // sync must run after install+link so the missing transitives are present
     // in theia-ide/node_modules to copy from
     syncMissingFrameworkDeps();
     run('yarn build:extensions', ROOT_DIR, 'Build IDE extensions');
@@ -488,14 +499,14 @@ async function main() {
             console.log('\nSkipping Theia build (--skip-theia-build)');
         }
 
-        // Link packages
-        linkTheiaPackages();
-
-        // Build IDE
+        // Build IDE. buildIde installs, then links, then builds. When the
+        // build is skipped, still link so an existing build / packaging step
+        // uses the requested checkout.
         if (!options.skipIdeBuild) {
             buildIde();
         } else {
             console.log('\nSkipping IDE build (--skip-ide-build)');
+            linkTheiaPackages();
         }
 
         // Package if requested


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Linking against a non-default --theia-path (e.g. a git worktree of theia) did not work reliably, and bundling/packaging still failed to resolve some transitive deps (e.g. b4a) from the framework checkout.

- symlink @theia/* into the IDE node_modules pointing at the exact --theia-path, instead of yarn's global link registry
- copy transitive deps that the linked packages cannot resolve from the checkout into its node_modules, during both build and packaging
- add a build:local-theia convenience script and update the docs

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Test the local build with a theia git worktree

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

