### PR TITLE
fix(sign): make macOS signing work on the OpenSSH 9 / macOS 15 node

### DIFF
--- a/applications/electron/scripts/notarize.sh
+++ b/applications/electron/scripts/notarize.sh
@@ -15,7 +15,7 @@ if [ -d "${INPUT}" ]; then
 fi
 
 # copy file to storage server
-scp -p "${INPUT}" genie.theia@projects-storage.eclipse.org:./
+scp -O -p "${INPUT}" genie.theia@projects-storage.eclipse.org:./
 rm -f "${INPUT}"
 
 # name to use on server
@@ -49,7 +49,7 @@ fi
 ssh -q genie.theia@projects-storage.eclipse.org curl -o "\"stapled-${REMOTE_NAME}\"" https://cbi.eclipse.org/macos/xcrun/${UUID}/download
 
 # copy stapled file back from server
-scp -T -p genie.theia@projects-storage.eclipse.org:"\"./stapled-${REMOTE_NAME}\"" "${INPUT}"
+scp -O -T -p genie.theia@projects-storage.eclipse.org:"\"./stapled-${REMOTE_NAME}\"" "${INPUT}"
 
 # ensure storage server is clean
 ssh -q genie.theia@projects-storage.eclipse.org rm -f "\"${REMOTE_NAME}\"" "\"stapled-${REMOTE_NAME}\"" entitlements.plist

--- a/applications/electron/scripts/sign-directory.ts
+++ b/applications/electron/scripts/sign-directory.ts
@@ -97,7 +97,7 @@ const signFile = (file: string) => {
     }
 
     console.log(`Signing ${file}...`);
-    child_process.spawnSync(signCommand, [
+    const result = child_process.spawnSync(signCommand, [
         path.basename(file),
         entitlements
     ], {
@@ -108,12 +108,34 @@ const signFile = (file: string) => {
         encoding: 'utf-8'
     });
 
+    // Fail hard if the signing command could not be spawned or exited with an error.
+    // Otherwise a broken signing step (e.g. an unreachable signing host) is silently
+    // ignored and produces an unsigned bundle that only fails much later at notarization.
+    if (result.error) {
+        throw new Error(`Failed to run signing command for ${file}: ${result.error.message}`);
+    }
+    if (result.status !== 0) {
+        throw new Error(`Signing command failed for ${file} with exit code ${result.status ?? `signal ${result.signal}`}.`);
+    }
+
     // Get SHA hash of file after signing - only for actual files, not directories
     if (stat.isFile()) {
         const shaAfterSigning = child_process.execSync(`shasum -a 256 "${file}"`).toString().trim();
-        // Log a warning if the SHA hash hasn't changed after signing
         if (shaBeforeSigning === shaAfterSigning) {
-            console.warn(`WARNING: SHA hash did not change after signing for ${file}. This might indicate the file was not properly signed.`);
+            // The signing service only signs Mach-O binaries and leaves other executables
+            // (e.g. shell scripts like jdtls, *.sh, mvnw) untouched. That is expected:
+            // Apple notarization only requires Mach-O executables to be signed. So only
+            // treat an unchanged *Mach-O* file as a hard error; otherwise just warn.
+            let isMachO = false;
+            try {
+                isMachO = child_process.execSync(`file "${file}"`).toString().includes('Mach-O');
+            } catch (e) {
+                // If 'file' cannot classify it, fall back to non-fatal.
+            }
+            if (isMachO) {
+                throw new Error(`SHA hash did not change after signing for ${file}. The Mach-O binary was not properly signed.`);
+            }
+            console.warn(`WARNING: SHA hash did not change after signing for ${file}. Skipping - not a Mach-O binary.`);
         }
     }
 
@@ -129,7 +151,10 @@ const argv = yargs(hideBin(process.argv))
     .wrap(120)
     .parseSync();
 
-execute();
+execute().catch(error => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exit(1);
+});
 
 async function execute(): Promise<void> {
     console.log(`signCommand: ${signCommand}; notarizeCommand: ${notarizeCommand}; entitlements: ${entitlements}; directory: ${argv.directory}`);
@@ -147,7 +172,7 @@ async function execute(): Promise<void> {
 
     // Notarize app
     console.log('Notarizing application...');
-    child_process.spawnSync(notarizeCommand, [
+    const notarizeResult = child_process.spawnSync(notarizeCommand, [
         path.basename(argv.directory),
         'eclipse.theia'
     ], {
@@ -157,4 +182,11 @@ async function execute(): Promise<void> {
         stdio: 'inherit',
         encoding: 'utf-8'
     });
+
+    if (notarizeResult.error) {
+        throw new Error(`Failed to run notarization command: ${notarizeResult.error.message}`);
+    }
+    if (notarizeResult.status !== 0) {
+        throw new Error(`Notarization command failed with exit code ${notarizeResult.status ?? `signal ${notarizeResult.signal}`}.`);
+    }
 }

--- a/applications/electron/scripts/sign.sh
+++ b/applications/electron/scripts/sign.sh
@@ -20,7 +20,7 @@ fi
 
 # copy file to storage server
 echo "=== DEBUG: Copying $INPUT to storage server ==="
-scp -p "${INPUT}" genie.theia@projects-storage.eclipse.org:./
+scp -O -p "${INPUT}" genie.theia@projects-storage.eclipse.org:./
 if [ $? -eq 0 ]; then
     echo "=== DEBUG: Successfully copied $INPUT to storage server ==="
 else
@@ -31,7 +31,7 @@ rm -f "${INPUT}"
 
 # copy entitlements to storage server
 echo "=== DEBUG: Copying entitlements file to storage server ==="
-scp -p "${ENTITLEMENTS}" genie.theia@projects-storage.eclipse.org:./entitlements.plist
+scp -O -p "${ENTITLEMENTS}" genie.theia@projects-storage.eclipse.org:./entitlements.plist
 if [ $? -eq 0 ]; then
     echo "=== DEBUG: Successfully copied entitlements to storage server ==="
 else
@@ -56,7 +56,7 @@ fi
 
 # copy signed file back from server
 echo "=== DEBUG: Copying signed file back from storage server ==="
-scp -T -p genie.theia@projects-storage.eclipse.org:"\"./signed-${REMOTE_NAME}\"" "${INPUT}"
+scp -O -T -p genie.theia@projects-storage.eclipse.org:"\"./signed-${REMOTE_NAME}\"" "${INPUT}"
 if [ $? -eq 0 ]; then
     echo "=== DEBUG: Successfully retrieved signed file ==="
 else


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

- Pass scp -O in sign.sh/notarize.sh to force the legacy SCP protocol, so quoted remote paths resolve on OpenSSH 9.x (fixes signed-file copy-back)
- Fail the build on signing/notarization errors instead of swallowing them
- Only treat an unchanged hash as fatal for Mach-O binaries; warn for scripts (jdtls, *.sh, mvnw, ...) the CBI service leaves untouched

Remark: the build job currently was set to this branch to build the preview. After this was merged we can configure the job back again to `master`.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

See the latest run (`#110`) of the Jenkins build here: https://ci.eclipse.org/theia/job/theia-ide-release/.
Run `#106` already was the first run on the new MacOS 15 node but the described scp commands were failing silently.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

