### PR TITLE
Fix automatic update check notifications

### DIFF
--- a/theia-extensions/updater/src/common/updater/theia-updater.ts
+++ b/theia-extensions/updater/src/common/updater/theia-updater.ts
@@ -18,7 +18,7 @@ export interface UpdaterSettings {
 }
 
 export interface TheiaUpdater extends RpcServer<TheiaUpdaterClient> {
-    checkForUpdates(): void;
+    checkForUpdates(notifyIfNoUpdate?: boolean): void;
     downloadUpdate(): void;
     onRestartToUpdateRequested(): void;
     disconnectClient(client: TheiaUpdaterClient): void;
@@ -40,10 +40,11 @@ export interface UpdateInfo {
 export interface UpdateAvailabilityInfo {
     available: boolean;
     updateInfo?: UpdateInfo;
+    notifyIfNoUpdate: boolean;
 }
 
 export interface TheiaUpdaterClient {
-    updateAvailable(available: boolean, updateInfo?: UpdateInfo): void;
+    updateAvailable(available: boolean, updateInfo?: UpdateInfo, notifyIfNoUpdate?: boolean): void;
     notifyReadyToInstall(): void;
     reportError(error: UpdaterError): void;
     reportCancelled(): void;

--- a/theia-extensions/updater/src/electron-browser/updater/theia-updater-frontend-contribution.ts
+++ b/theia-extensions/updater/src/electron-browser/updater/theia-updater-frontend-contribution.ts
@@ -67,8 +67,8 @@ export class TheiaUpdaterClientImpl implements TheiaUpdaterClient {
         this.onReadyToInstallEmitter.fire();
     }
 
-    updateAvailable(available: boolean, updateInfo?: UpdateInfo): void {
-        this.onUpdateAvailableEmitter.fire({ available, updateInfo });
+    updateAvailable(available: boolean, updateInfo?: UpdateInfo, notifyIfNoUpdate = true): void {
+        this.onUpdateAvailableEmitter.fire({ available, updateInfo, notifyIfNoUpdate });
     }
 
     reportError(error: UpdaterError): void {
@@ -127,11 +127,11 @@ export class TheiaUpdaterFrontendContribution implements CommandContribution, Me
 
     @postConstruct()
     protected init(): void {
-        this.updaterClient.onUpdateAvailable(({ available, updateInfo }) => {
+        this.updaterClient.onUpdateAvailable(({ available, updateInfo, notifyIfNoUpdate }) => {
             if (available) {
                 this.currentUpdateInfo = updateInfo;
                 this.handleDownloadUpdate(updateInfo);
-            } else {
+            } else if (notifyIfNoUpdate) {
                 this.handleNoUpdate();
             }
         });

--- a/theia-extensions/updater/src/electron-main/update/theia-updater-impl.ts
+++ b/theia-extensions/updater/src/electron-main/update/theia-updater-impl.ts
@@ -48,12 +48,14 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
 
     private initialCheck: boolean = true;
     private reportOnFirstRegistration: boolean = false;
+    private notifyIfNoUpdate: boolean = false;
     private cancellationToken: CancellationToken = new CancellationToken();
     private updateCheckTimer: NodeJS.Timeout | undefined;
 
     constructor() {
         autoUpdater.autoDownload = false;
         autoUpdater.on('update-available', (info: { version: string }) => {
+            this.notifyIfNoUpdate = false;
             if (this.initialCheck) {
                 this.initialCheck = false;
                 if (this.clients.length === 0) {
@@ -64,11 +66,12 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
             this.clients.forEach(c => c.updateAvailable(true, updateInfo));
         });
         autoUpdater.on('update-not-available', () => {
+            const notifyIfNoUpdate = this.notifyIfNoUpdate;
+            this.notifyIfNoUpdate = false;
             if (this.initialCheck) {
                 this.initialCheck = false;
-                return;
             }
-            this.clients.forEach(c => c.updateAvailable(false));
+            this.clients.forEach(c => c.updateAvailable(false, undefined, notifyIfNoUpdate));
         });
 
         autoUpdater.on('update-downloaded', () => {
@@ -76,6 +79,7 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
         });
 
         autoUpdater.on('error', (err: unknown) => {
+            this.notifyIfNoUpdate = false;
             if (err instanceof Error && err.message.includes('cancelled')) {
                 return;
             }
@@ -84,7 +88,8 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
         });
     }
 
-    checkForUpdates(): void {
+    checkForUpdates(notifyIfNoUpdate = true): void {
+        this.notifyIfNoUpdate = this.notifyIfNoUpdate || notifyIfNoUpdate;
         const feedURL = this.getFeedURL(this.settings.channel);
         autoUpdater.setFeedURL(feedURL);
         autoUpdater.checkForUpdates();
@@ -142,13 +147,13 @@ export class TheiaUpdaterImpl implements TheiaUpdater, ElectronMainApplicationCo
             return;
         }
 
-        this.checkForUpdates();
+        this.checkForUpdates(false);
 
         const intervalMs = Math.max(this.settings.checkInterval, 1) * 60 * 1000;
 
         this.updateCheckTimer = setInterval(() => {
             if (this.settings.checkForUpdates) {
-                this.checkForUpdates();
+                this.checkForUpdates(false);
             }
         }, intervalMs);
     }


### PR DESCRIPTION
#### What it does

- Keeps startup and interval update checks silent when no update is available.
- Preserves the existing `Already using the latest version` feedback for the explicit **Check for Updates...** command.
- Carries the notification intent through the existing updater RPC flow and preserves manual intent when checks overlap.

Fixes #693

#### How to test

1. Run a build that is already on the latest version with automatic update checks enabled.
2. Start the application and verify the automatic check does not show `Already using the latest version`.
3. Run **Check for Updates...** and verify the same no-update result does show that message.
4. Verify an available update still shows the existing update prompt.

Local verification included a focused updater-flow behavior harness, TypeScript no-emit checking, repository ESLint for all changed files, and `git diff --check`.

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
