### PR TITLE
fix: match StartupWMClass to the WM_CLASS reported by Electron 42

### DIFF
--- a/theia-extensions/launcher/src/node/desktopfile-endpoint.ts
+++ b/theia-extensions/launcher/src/node/desktopfile-endpoint.ts
@@ -159,7 +159,7 @@ Exec=${appImagePath} %U
 Terminal=false
 Type=Application
 Icon=${imagePath}
-StartupWMClass=${applicationName}
+StartupWMClass=${this.getAppId(applicationName)}
 Comment=IDE for cloud and desktop
 Categories=Development;IDE;`;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Fixes a Linux launcher regression introduced by the Electron 42 update (GH-750): the AppImage window is no longer grouped under its pinned launcher.

The generated AppImage `.desktop` file set `StartupWMClass` to the display name (e.g. `Theia IDE Next`), but Electron 42 reports the normalized X11 `WM_CLASS` (`theia-ide-next`). GNOME therefore showed a second, ungrouped icon instead of using the pinned launcher. `StartupWMClass` now uses `getAppId(applicationName)`, which yields the same normalized value the runtime reports (`theia-ide` for stable, `theia-ide-next` for next).

The change is in the shared launcher extension, so it applies to both the stable and next apps. Existing installs self-heal on the next start via the `needs-silent-update` path, since the template content changed.

#### How to test

The feature is AppImage-only (`process.env.APPIMAGE`), so testing uses sandbox env vars to avoid touching real configs.

```bash
# sandbox (from repo root)
mkdir -p /tmp/launchertest/{appdir,xdg,config}
touch /tmp/launchertest/appdir/icon.png
touch /tmp/launchertest/Theia-IDE.AppImage

yarn && yarn build:extensions && yarn electron build

export APPIMAGE=/tmp/launchertest/Theia-IDE.AppImage
export APPDIR=/tmp/launchertest/appdir
export XDG_DATA_HOME=/tmp/launchertest/xdg
export THEIA_CONFIG_DIR=/tmp/launchertest/config
rm -rf /tmp/launchertest/xdg /tmp/launchertest/config

yarn electron start
```

1. On the **"Create .desktop file"** dialog click **Yes** (dismiss the unrelated "Create launcher" dialog with **No**).
2. Verify the written class matches the normalized name:

   ```bash
   grep StartupWMClass /tmp/launchertest/xdg/applications/*-launcher.desktop
   # Expect: StartupWMClass=theia-ide   (or theia-ide-next for the next build)
   ```

**End-to-end grouping** (real AppImage, the actual user-facing verification): build and run the real AppImage, then with the window open:

```bash
xprop WM_CLASS            # click the window -> theia-ide / theia-ide-next
grep StartupWMClass ~/.local/share/applications/theia-ide*-launcher.desktop
```

Both should read the same value; the window then groups under the pinned launcher. Unpin/re-pin once, since GNOME caches the old association.

#### Follow-ups

- A separate fix for the CLI launcher install crash on Node 23+ (`@vscode/sudo-prompt`)

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the review guidelines


