### PR TITLE
fix: bump @vscode/sudo-prompt to 9.3.2 for Node 23+ bundled with Electron 42

### DIFF
--- a/theia-extensions/launcher/package.json
+++ b/theia-extensions/launcher/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "@theia/core": "1.74.0-next.33",
-    "@vscode/sudo-prompt": "9.3.1",
+    "@vscode/sudo-prompt": "9.3.2",
     "body-parser": "^1.20.5",
     "fs-extra": "^4.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4739,10 +4739,10 @@
     "@vscode/ripgrep-win32-ia32" "1.18.0"
     "@vscode/ripgrep-win32-x64" "1.18.0"
 
-"@vscode/sudo-prompt@9.3.1":
-  version "9.3.1"
-  resolved "https://registry.yarnpkg.com/@vscode/sudo-prompt/-/sudo-prompt-9.3.1.tgz#c562334bc6647733649fd42afc96c0eea8de3b65"
-  integrity sha512-9ORTwwS74VaTn38tNbQhsA5U44zkJfcb0BdTSyyG6frP4e8KMtHuTXYmwefe5dpL8XB1aGSIVTaLjD3BbWb5iA==
+"@vscode/sudo-prompt@9.3.2":
+  version "9.3.2"
+  resolved "https://registry.yarnpkg.com/@vscode/sudo-prompt/-/sudo-prompt-9.3.2.tgz#692ba38df40bd3502ccc4e9f099fbbaedbd5f04e"
+  integrity sha512-gcXoCN00METUNFeQOFJ+C9xUI0DKB+0EGMVg7wbVYRHBw2Eq3fKisDZOkRdOz3kqXRKOENMfShPOmypw1/8nOw==
 
 "@vscode/windows-ca-certs@^0.3.1":
   version "0.3.4"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Fixes the CLI launcher install regression introduced by the Electron 42 update (GH-750).

The "Create CLI Launcher" flow crashed before showing the OS password prompt with `TypeError: util.isObject is not a function`. `@vscode/sudo-prompt@9.3.1` calls the legacy `util.isObject`/`util.isFunction` helpers, which were removed in Node 23 (bundled with Electron 42), so `sudo.exec` threw synchronously and the install silently aborted after the confirmation dialog.

`@vscode/sudo-prompt@9.3.2` replaces those calls with local type checks upstream. This PR just bumps the dependency `9.3.1` → `9.3.2`. No source or behavior change, and cross-platform elevation (macOS `osascript`, Windows UAC, Linux `pkexec`) is preserved.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The install path only runs from an AppImage (`process.env.APPIMAGE`).

```bash
# build + package (next build shown; use `electron` for stable)
yarn && yarn build:extensions && yarn build:applications:next && yarn electron-next package

# run with a sandbox config so ~/.theia is untouched and the prompt fires fresh
export THEIA_CONFIG_DIR=/tmp/theia-clitest
rm -rf /tmp/theia-clitest
./applications/electron-next/dist/TheiaIDENext.AppImage
```

1. On startup the **"Create launcher"** dialog appears. Click **Confirm**.
2. **Expect:** the OS polkit password dialog now appears (before this fix, nothing happened and the backend logged a `TypeError`). Enter your password.
3. Verify the launcher was installed and works:

   ```bash
   ls -l /usr/local/bin/theia-next     # exists, mode 755
   theia-next --version                # prints the version
   ```

To reset, remove the launcher with `sudo rm -f /usr/local/bin/theia-next`; the app re-creates it on the next start anyway.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

