### PR TITLE
fix(electron-next): Theia IDE next update channel and branding variant

### DIFF
--- a/applications/electron-next/package.json
+++ b/applications/electron-next/package.json
@@ -24,14 +24,14 @@
     "frontend": {
       "config": {
         "applicationName": "Theia IDE Next",
-        "brandingVariant": "1.75.0-next.21",
+        "brandingVariant": "next",
         "availableUpdateChannels": [
-          "1.75.0-next.21"
+          "next"
         ],
         "reloadOnReconnect": true,
         "preferences": {
           "toolbar.showToolbar": true,
-          "updates.channel": "1.75.0-next.21",
+          "updates.channel": "next",
           "ai-features.chat.tokenUsageIndicator.enabled": true
         },
         "electron": {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Follow up of GH-766

Fixes the update channel and the branding variant for the Theia IDE next application which was accidentally overridden with the linked electron bump.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

