### PR TITLE
Enable walkthroughs and rework the welcome page

### DIFF
--- a/theia-extensions/product/src/browser/branding-util.tsx
+++ b/theia-extensions/product/src/browser/branding-util.tsx
@@ -22,7 +22,7 @@ export interface ExternalBrowserLinkProps {
 export function renderProductName(): React.ReactNode {
     const variant = getBrandingVariant();
     const suffix = variant !== 'stable' ? ` ${variant.charAt(0).toUpperCase() + variant.slice(1)}` : '';
-    return <h1>Eclipse Theia <span className="gs-blue-header">IDE</span>{suffix}</h1>;
+    return <h1>Eclipse Theia <span className="tide-branding-accent">IDE</span>{suffix}</h1>;
 }
 
 export const DOWNLOAD_URL = 'https://theia-ide.org/#theiaidedownload';

--- a/theia-extensions/product/src/browser/branding-util.tsx
+++ b/theia-extensions/product/src/browser/branding-util.tsx
@@ -7,7 +7,9 @@
  * SPDX-License-Identifier: MIT
  ********************************************************************************/
 
+import { codicon } from '@theia/core/lib/browser';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
+import { environment } from '@theia/core/lib/common';
 import * as React from 'react';
 import { getBrandingVariant } from './theia-ide-config';
 
@@ -23,6 +25,8 @@ export function renderProductName(): React.ReactNode {
     return <h1>Eclipse Theia <span className="gs-blue-header">IDE</span>{suffix}</h1>;
 }
 
+export const DOWNLOAD_URL = 'https://theia-ide.org/#theiaidedownload';
+
 function BrowserLink(props: ExternalBrowserLinkProps): React.JSX.Element {
     return <a
         role={'button'}
@@ -34,20 +38,25 @@ function BrowserLink(props: ExternalBrowserLinkProps): React.JSX.Element {
     </a>;
 }
 
+/*
+ * The sections below are shared by the welcome page and the About dialog, so that both describe the product
+ * in the same words. Keep them to a sentence or two each: the welcome page has to stay scannable.
+ */
+
 export function renderWhatIs(windowService: WindowService): React.ReactNode {
     return <div className='gs-section'>
         <h3 className='gs-section-header'>
+            <i className={codicon('info')}></i>
             What is this?
         </h3>
         <div>
-            The Eclipse Theia IDE is a modern and open IDE for cloud and desktop. The Theia IDE is based on the <BrowserLink text="Theia platform"
-                url="https://theia-ide.org" windowService={windowService} ></BrowserLink>.
+            The Eclipse Theia IDE is a modern and open IDE for cloud and desktop, built on
+            the <BrowserLink text="Theia platform" url="https://theia-ide.org" windowService={windowService} />.
         </div>
         <div>
-            The IDE is available as a <BrowserLink text="downloadable desktop application" url="https://theia-ide.org//#theiaidedownload"
-                windowService={windowService} ></BrowserLink>. You can also <BrowserLink text="try the latest version of the Theia IDE online"
-                    url="https://try.theia-cloud.io/" windowService={windowService} ></BrowserLink>. The online test version is limited to 30 minutes per session and hosted
-            via <BrowserLink text="Theia Cloud" url="https://theia-cloud.io/" windowService={windowService} ></BrowserLink>.
+            You can get it as a <BrowserLink text="desktop application" url={DOWNLOAD_URL} windowService={windowService} /> or <BrowserLink
+                text="try the latest version online" url="https://try.theia-cloud.io/" windowService={windowService} />. The online version is limited to
+            30 minutes per session and hosted on <BrowserLink text="Theia Cloud" url="https://theia-cloud.io/" windowService={windowService} />.
         </div>
     </div>;
 }
@@ -55,76 +64,18 @@ export function renderWhatIs(windowService: WindowService): React.ReactNode {
 export function renderExtendingCustomizing(windowService: WindowService): React.ReactNode {
     return <div className='gs-section'>
         <h3 className='gs-section-header'>
-            Extending/Customizing the Theia IDE
-        </h3>
-        <div >
-            You can extend the Theia IDE at runtime by installing VS Code extensions, e.g. from the <BrowserLink text="OpenVSX registry" url="https://open-vsx.org/"
-                windowService={windowService} ></BrowserLink>, an open marketplace for VS Code extensions. Just open the extension view or browse <BrowserLink
-                    text="OpenVSX online" url="https://open-vsx.org/" windowService={windowService} ></BrowserLink>.
-        </div>
-        <div>
-            Furthermore, the Theia IDE is based on the flexible Theia platform. Therefore, the Theia IDE can serve as a <span className='gs-text-bold'>template</span> for building
-            custom tools and IDEs. Browse <BrowserLink text="the documentation" url="https://theia-ide.org/docs/composing_applications/"
-                windowService={windowService} ></BrowserLink> to help you customize and build your own Eclipse Theia-based product.
-        </div>
-    </div>;
-}
-
-export function renderSupport(windowService: WindowService): React.ReactNode {
-    return <div className='gs-section'>
-        <h3 className='gs-section-header'>
-            Professional Support
+            <i className={codicon('extensions')}></i>
+            Extending &amp; Customizing
         </h3>
         <div>
-            Professional support, implementation services, consulting and training for building tools like Theia IDE and for building other tools based on Eclipse Theia is
-            available by selected companies as listed on the <BrowserLink text=" Theia support page" url="https://theia-ide.org/support/"
-                windowService={windowService} ></BrowserLink>.
-        </div>
-    </div>;
-}
-
-export function renderTickets(windowService: WindowService): React.ReactNode {
-    return <div className='gs-section'>
-        <h3 className='gs-section-header'>
-            Reporting feature requests and bugs
-        </h3>
-        <div >
-            The features in the Eclipse Theia IDE are based on Theia and the included
-            extensions/plugins. For bugs in Theia please consider opening an issue in
-            the <BrowserLink text="Theia project on Github" url="https://github.com/eclipse-theia/theia/issues/new/choose"
-                windowService={windowService} ></BrowserLink>.
+            You can extend the IDE at runtime by installing VS Code extensions from
+            the <BrowserLink text="Open VSX registry" url="https://open-vsx.org/" windowService={windowService} />, an open marketplace. Open the Extensions
+            view to browse them.
         </div>
         <div>
-            Eclipse Theia IDE only packages existing functionality into a product and installers
-            for the product. If you believe there is a mistake in packaging, something needs to be added to the
-            packaging or the installers do not work properly,
-            please <BrowserLink text="open an issue on Github" url="https://github.com/eclipse-theia/theia-ide/issues/new/choose"
-                windowService={windowService} ></BrowserLink> to let us know.
-        </div>
-    </div>;
-}
-
-export function renderSourceCode(windowService: WindowService): React.ReactNode {
-    return <div className='gs-section'>
-        <h3 className='gs-section-header'>
-            Source Code
-        </h3>
-        <div >
-            The source code of Eclipse Theia IDE is available
-            on <BrowserLink text="Github" url="https://github.com/eclipse-theia/theia-ide"
-                windowService={windowService} ></BrowserLink>.
-        </div>
-    </div>;
-}
-
-export function renderDocumentation(windowService: WindowService): React.ReactNode {
-    return <div className='gs-section'>
-        <h3 className='gs-section-header'>
-            Documentation
-        </h3>
-        <div >
-            Please see the <BrowserLink text="documentation" url="https://theia-ide.org/docs/user_getting_started/"
-                windowService={windowService} ></BrowserLink> on how to use the Theia IDE.
+            The IDE is built on the flexible Theia platform, so it can also serve as
+            a <span className='gs-text-bold'>template</span> for your own tools and IDEs. See
+            the <BrowserLink text="documentation" url="https://theia-ide.org/docs/composing_applications/" windowService={windowService} /> to get started.
         </div>
     </div>;
 }
@@ -132,30 +83,91 @@ export function renderDocumentation(windowService: WindowService): React.ReactNo
 export function renderCollaboration(windowService: WindowService): React.ReactNode {
     return <div className='gs-section'>
         <h3 className='gs-section-header'>
+            <i className={codicon('live-share')}></i>
             Collaboration
         </h3>
-        <div >
-            The IDE features a built-in collaboration feature.
-            You can share your workspace with others and work together in real-time by clicking on the <i>Collaborate</i> item in the status bar.
-            The collaboration feature is powered by
-            the <BrowserLink text="Open Collaboration Tools" url="https://www.open-collab.tools/" windowService={windowService} /> project
-            and uses their public server infrastructure.
+        <div>
+            Share your workspace with others and work together in real time by clicking <i>Collaborate</i> in the status bar. The feature is powered
+            by <BrowserLink text="Open Collaboration Tools" url="https://www.open-collab.tools/" windowService={windowService} /> and uses their public
+            server infrastructure.
         </div>
     </div>;
 }
 
-export function renderDownloads(): React.ReactNode {
+export function renderSupport(windowService: WindowService): React.ReactNode {
     return <div className='gs-section'>
         <h3 className='gs-section-header'>
-            Updates and Downloads
+            <i className={codicon('organization')}></i>
+            Professional Support
         </h3>
-        <div className='gs-action-container'>
-            You can update Eclipse Theia IDE directly in this application by navigating to
-            File {'>'} Preferences {'>'} Check for Updates… Moreover the application will check for updates
-            after each launch automatically.
-        </div>
-        <div className='gs-action-container'>
-            Alternatively you can download the most recent version from the download page.
+        <div>
+            Professional support, implementation services, consulting and training for the Theia IDE and for other tools based on Eclipse Theia are available
+            from selected companies. They are listed on
+            the <BrowserLink text="Theia support page" url="https://theia-ide.org/support/" windowService={windowService} />.
         </div>
     </div>;
+}
+
+export function renderCommunity(windowService: WindowService): React.ReactNode {
+    return <div className='gs-section'>
+        <h3 className='gs-section-header'>
+            <i className={codicon('comment-discussion')}></i>
+            Community
+        </h3>
+        <div>
+            The features of the Theia IDE come from Theia and the included extensions, while this project packages them into a product and its installers. So
+            please report a bug in a feature to the <BrowserLink text="Theia project"
+                url="https://github.com/eclipse-theia/theia/issues/new/choose" windowService={windowService} />, and anything wrong with the packaging or the
+            installers to the <BrowserLink text="Theia IDE project" url="https://github.com/eclipse-theia/theia-ide/issues/new/choose"
+                windowService={windowService} />.
+        </div>
+        <div>
+            The <BrowserLink text="source code" url="https://github.com/eclipse-theia/theia-ide" windowService={windowService} /> of the Theia IDE is available
+            on GitHub.
+        </div>
+    </div>;
+}
+
+export interface BrandingProps {
+    windowService: WindowService;
+}
+
+/**
+ * Renders nothing outside of the desktop application: the updater and its `updates.*` preferences are
+ * contributed by `theia-ide-updater-ext`, which is part of the Electron builds only.
+ */
+export function renderUpdates(props: BrandingProps): React.ReactNode {
+    if (!environment.electron.is()) {
+        return undefined;
+    }
+    return <div className='gs-section'>
+        <h3 className='gs-section-header'>
+            <i className={codicon('cloud-download')}></i>
+            Updates
+        </h3>
+        <div>
+            You can update the Theia IDE directly in this application. It also checks for updates automatically after each launch.
+        </div>
+        <div>
+            You can also download the most recent version from
+            the <BrowserLink text="download page" url={DOWNLOAD_URL} windowService={props.windowService} />.
+        </div>
+    </div>;
+}
+
+/**
+ * The product description as shown by both the welcome page and the About dialog. Sharing the whole list
+ * rather than only the individual sections keeps the two from drifting apart as sections come and go.
+ */
+export function renderBrandingSections(props: BrandingProps): React.ReactNode {
+    const row = (content: React.ReactNode) => <div className='flex-grid'><div className='col'>{content}</div></div>;
+    const updates = renderUpdates(props);
+    return <React.Fragment>
+        {row(renderWhatIs(props.windowService))}
+        {row(renderExtendingCustomizing(props.windowService))}
+        {row(renderCollaboration(props.windowService))}
+        {row(renderSupport(props.windowService))}
+        {row(renderCommunity(props.windowService))}
+        {updates && row(updates)}
+    </React.Fragment>;
 }

--- a/theia-extensions/product/src/browser/branding-util.tsx
+++ b/theia-extensions/product/src/browser/branding-util.tsx
@@ -146,7 +146,8 @@ export function renderUpdates(props: BrandingProps): React.ReactNode {
             Updates
         </h3>
         <div>
-            You can update the Theia IDE directly in this application. It also checks for updates automatically after each launch.
+            You can update the Theia IDE directly in this application from Help {'>'} Check for Updates… It also checks for updates automatically
+            after each launch.
         </div>
         <div>
             You can also download the most recent version from

--- a/theia-extensions/product/src/browser/style/index.css
+++ b/theia-extensions/product/src/browser/style/index.css
@@ -9,6 +9,7 @@
 
 :root {
     --theia-branding-logo: url(../icons/TheiaIDE.png);
+    --theia-branding-accent: #5088e7;
 }
 
 .theia-icon {
@@ -20,6 +21,8 @@
 
 body[data-theia-branding="next"] {
     --theia-branding-logo: url(../icons/TheiaIDE-next.png);
+    /* The exact purple of the `next` application icon, so the product name matches it. */
+    --theia-branding-accent: #8b5cf6;
 }
 
 body[data-theia-branding="next"] .theia-icon {
@@ -27,7 +30,7 @@ body[data-theia-branding="next"] .theia-icon {
 }
 
 .gs-blue-header {
-    color: #5088e7;
+    color: var(--theia-branding-accent);
     text-transform: capitalize;
     font-weight: 600;
 }
@@ -40,19 +43,65 @@ body[data-theia-branding="next"] .theia-icon {
     text-decoration: underline;
 }
 
-.gs-float {
-    float: right;
-    padding-left: 20px;
+/*
+ * The welcome page lays out its sections in two columns: what you can do on the left, what the IDE is on
+ * the right. `auto-fit` folds them into a single column on a narrow editor without needing a media query.
+ */
+.tide-welcome-grid {
+    display: grid;
+    /*
+     * `min()` keeps the track from staying at 320px once the widget gets narrower than that: the welcome
+     * widget suppresses horizontal scrolling, so anything wider than it would be clipped rather than
+     * reachable.
+     */
+    grid-template-columns: repeat(auto-fit, minmax(min(320px, 100%), 1fr));
+    gap: calc(var(--theia-ui-padding) * 4);
+    align-items: start;
 }
 
-.gs-logo {
-    background-image: var(--theia-branding-logo);
-    background-position: center center;
-    background-repeat: no-repeat;
-    background-size: contain;
-    width: 250px;
-    height: 118px;
-    padding: 20px;
+.tide-welcome-column {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--theia-ui-padding) * 3);
+    /* Keeps the recent workspace paths ellipsizing instead of widening the column. */
+    min-width: 0;
+}
+
+.tide-welcome-header {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: calc(var(--theia-ui-padding) * 3);
+}
+
+.tide-welcome-header h1 {
+    margin: 0;
+}
+
+.tide-welcome-header .gs-sub-header {
+    margin: calc(var(--theia-ui-padding) / 2) 0 0 0;
+}
+
+.tide-welcome-banner {
+    margin: calc(var(--theia-ui-padding) * 3) 0;
+}
+
+/* The banner is no longer nested in a floating box, so the full height it asks for has to be undone. */
+.tide-welcome-banner > .gs-container {
+    height: auto;
+}
+
+/*
+ * The header shows the square application icon rather than the wordmark logo. The icon is the same shape in
+ * every branding variant, so one box fits all of them, and being transparent it sits on a light and a dark
+ * theme alike. `.theia-icon` above supplies the image and swaps it per variant.
+ */
+.tide-welcome-header .tide-welcome-icon {
+    flex: 0 0 auto;
+    width: 64px;
+    height: 64px;
+    /* `.theia-icon` in core is sized and spaced for the browser menu bar logo. */
+    margin: 0;
 }
 
 .ad-logo {

--- a/theia-extensions/product/src/browser/style/index.css
+++ b/theia-extensions/product/src/browser/style/index.css
@@ -9,27 +9,43 @@
 
 :root {
     --theia-branding-logo: url(../icons/TheiaIDE.png);
+    --theia-branding-icon: url(../icons/512-512.png);
     --theia-branding-accent: #5088e7;
 }
 
+body[data-theia-branding="next"] {
+    --theia-branding-logo: url(../icons/TheiaIDE-next.png);
+    --theia-branding-icon: url(../icons/512-512-next.png);
+    /* The exact purple of the `next` application icon, so the product name matches it. */
+    --theia-branding-accent: #8b5cf6;
+}
+
 .theia-icon {
-    background-image: url("../icons/512-512.png");
+    background-image: var(--theia-branding-icon);
     background-position: center;
     background-repeat: no-repeat;
     background-size: contain;
 }
 
-body[data-theia-branding="next"] {
-    --theia-branding-logo: url(../icons/TheiaIDE-next.png);
-    /* The exact purple of the `next` application icon, so the product name matches it. */
-    --theia-branding-accent: #8b5cf6;
+/*
+ * The application icon on the welcome tab, so the tab is recognizable the way a favicon makes a page.
+ * Tab icons in the main area are drawn as a mask tinted with `--theia-icon-foreground`, which would flatten
+ * the brand color, so the icon is put back as a plain background image. Core does the same for file icons,
+ * hence the selectors have to be as specific as the rules in its `tabs.css`.
+ */
+.lm-TabBar.theia-app-centers .lm-TabBar-tabIcon.tide-welcome-tab-icon,
+.lm-TabBar-tab.lm-mod-drag-image .lm-TabBar-tabIcon.tide-welcome-tab-icon {
+    /*
+     * `content-box` keeps the icon out of the `padding-right` that core gives every tab icon as the gap
+     * before the label. Without it the background fills the padding box and eats into that gap.
+     */
+    background: var(--theia-branding-icon) center/contain no-repeat content-box;
+    -webkit-mask: none;
+    mask: none;
+    min-height: var(--theia-icon-size);
 }
 
-body[data-theia-branding="next"] .theia-icon {
-    background-image: url("../icons/512-512-next.png");
-}
-
-.gs-blue-header {
+.tide-branding-accent {
     color: var(--theia-branding-accent);
     text-transform: capitalize;
     font-weight: 600;

--- a/theia-extensions/product/src/browser/theia-ide-about-dialog.tsx
+++ b/theia-extensions/product/src/browser/theia-ide-about-dialog.tsx
@@ -10,7 +10,7 @@
 import * as React from 'react';
 import { AboutDialog, AboutDialogProps, ABOUT_CONTENT_CLASS } from '@theia/core/lib/browser/about-dialog';
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { renderDocumentation, renderDownloads, renderProductName, renderSourceCode, renderSupport, renderTickets, renderWhatIs } from './branding-util';
+import { renderBrandingSections, renderProductName } from './branding-util';
 import { VSXEnvironment } from '@theia/vsx-registry/lib/common/vsx-environment';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 @injectable()
@@ -50,36 +50,9 @@ export class TheiaIDEAboutDialog extends AboutDialog {
             </div>
             {this.renderTitle()}
             <hr className='gs-hr' />
-            <div className='flex-grid'>
-                <div className='col'>
-                    {renderWhatIs(this.windowService)}
-                </div>
-            </div>
-            <div className='flex-grid'>
-                <div className='col'>
-                    {renderSupport(this.windowService)}
-                </div>
-            </div>
-            <div className='flex-grid'>
-                <div className='col'>
-                    {renderTickets(this.windowService)}
-                </div>
-            </div>
-            <div className='flex-grid'>
-                <div className='col'>
-                    {renderSourceCode(this.windowService)}
-                </div>
-            </div>
-            <div className='flex-grid'>
-                <div className='col'>
-                    {renderDocumentation(this.windowService)}
-                </div>
-            </div>
-            <div className='flex-grid'>
-                <div className='col'>
-                    {renderDownloads()}
-                </div>
-            </div>
+            {renderBrandingSections({
+                windowService: this.windowService
+            })}
         </div>;
 
     }

--- a/theia-extensions/product/src/browser/theia-ide-getting-started-widget.tsx
+++ b/theia-extensions/product/src/browser/theia-ide-getting-started-widget.tsx
@@ -33,6 +33,8 @@ export class TheiaIDEGettingStartedWidget extends GettingStartedWidget {
 
     protected async doInit(): Promise<void> {
         super.doInit();
+        // Brand the tab with the application icon, the way a favicon marks a page.
+        this.title.iconClass = 'tide-welcome-tab-icon';
         this.vscodeApiVersion = await this.vsxEnvironment.getVscodeApiVersion();
         await this.preferenceService.ready;
         this.update();

--- a/theia-extensions/product/src/browser/theia-ide-getting-started-widget.tsx
+++ b/theia-extensions/product/src/browser/theia-ide-getting-started-widget.tsx
@@ -9,12 +9,9 @@
 
 import * as React from 'react';
 
-import { Message } from '@theia/core/lib/browser';
 import { PreferenceService } from '@theia/core/lib/common';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import {
-    renderDocumentation, renderDownloads, renderExtendingCustomizing, renderProductName, renderSourceCode, renderSupport, renderTickets, renderWhatIs, renderCollaboration
-} from './branding-util';
+import { renderBrandingSections, renderProductName } from './branding-util';
 
 import { GettingStartedWidget } from '@theia/getting-started/lib/browser/getting-started-widget';
 import { VSXEnvironment } from '@theia/vsx-registry/lib/common/vsx-environment';
@@ -24,7 +21,7 @@ import { WindowService } from '@theia/core/lib/browser/window/window-service';
 export class TheiaIDEGettingStartedWidget extends GettingStartedWidget {
 
     @inject(VSXEnvironment)
-    protected readonly environment: VSXEnvironment;
+    protected readonly vsxEnvironment: VSXEnvironment;
 
     @inject(WindowService)
     protected readonly windowService: WindowService;
@@ -36,77 +33,36 @@ export class TheiaIDEGettingStartedWidget extends GettingStartedWidget {
 
     protected async doInit(): Promise<void> {
         super.doInit();
-        this.vscodeApiVersion = await this.environment.getVscodeApiVersion();
+        this.vscodeApiVersion = await this.vsxEnvironment.getVscodeApiVersion();
         await this.preferenceService.ready;
         this.update();
     }
 
-    protected onActivateRequest(msg: Message): void {
-        super.onActivateRequest(msg);
-        const htmlElement = document.getElementById('alwaysShowWelcomePage');
-        if (htmlElement) {
-            htmlElement.focus();
-        }
-    }
-
     protected render(): React.ReactNode {
+        if (this.walkthroughService.selectedWalkthrough) {
+            return this.renderSelectedWalkthrough();
+        }
         return <div className='gs-container'>
             <div className='gs-content-container'>
-                <div className='gs-float'>
-                    <div className='gs-logo'>
-                    </div>
-                    {this.renderActions()}
-                </div>
                 {this.renderHeader()}
                 <hr className='gs-hr' />
-                <div className='flex-grid'>
-                    <div className='col'>
-                        {this.renderNews()}
-                    </div>
-                </div>
-                <div className='flex-grid'>
-                    <div className='col'>
-                        {renderWhatIs(this.windowService)}
-                    </div>
-                </div>
-                <div className='flex-grid'>
-                    <div className='col'>
-                        {renderExtendingCustomizing(this.windowService)}
-                    </div>
-                </div>
-                <div className='flex-grid'>
-                    <div className='col'>
-                        {renderSupport(this.windowService)}
-                    </div>
-                </div>
-                <div className='flex-grid'>
-                    <div className='col'>
-                        {renderTickets(this.windowService)}
-                    </div>
-                </div>
-                <div className='flex-grid'>
-                    <div className='col'>
-                        {renderSourceCode(this.windowService)}
-                    </div>
-                </div>
-                <div className='flex-grid'>
-                    <div className='col'>
-                        {renderDocumentation(this.windowService)}
-                    </div>
-                </div>
-                <div className='flex-grid'>
-                    <div className='col'>
+                {this.aiIsIncluded &&
+                    <div className='tide-welcome-banner'>
                         {this.renderAIBanner()}
                     </div>
-                </div>
-                <div className='flex-grid'>
-                    <div className='col'>
-                        {renderCollaboration(this.windowService)}
+                }
+                <div className='tide-welcome-grid'>
+                    <div className='tide-welcome-column'>
+                        {this.renderStart()}
+                        {this.renderRecentWorkspaces()}
+                        {this.renderWalkthroughs()}
+                        {this.renderSettings()}
+                        {this.renderHelp()}
                     </div>
-                </div>
-                <div className='flex-grid'>
-                    <div className='col'>
-                        {renderDownloads()}
+                    <div className='tide-welcome-column'>
+                        {renderBrandingSections({
+                            windowService: this.windowService
+                        })}
                     </div>
                 </div>
             </div>
@@ -116,55 +72,27 @@ export class TheiaIDEGettingStartedWidget extends GettingStartedWidget {
         </div>;
     }
 
-    protected renderActions(): React.ReactNode {
-        return <div className='gs-container'>
-            <div className='flex-grid'>
-                <div className='col'>
-                    {this.renderStart()}
-                </div>
-            </div>
-            <div className='flex-grid'>
-                <div className='col'>
-                    {this.renderRecentWorkspaces()}
-                </div>
-            </div>
-            <div className='flex-grid'>
-                <div className='col'>
-                    {this.renderSettings()}
-                </div>
-            </div>
-            <div className='flex-grid'>
-                <div className='col'>
-                    {this.renderHelp()}
-                </div>
-            </div>
-        </div>;
-    }
-
+    /**
+     * The square application icon is used rather than the wordmark logo: it carries the brand without
+     * repeating the product name next to it, and the same box fits every branding variant.
+     */
     protected renderHeader(): React.ReactNode {
-        return <div className='gs-header'>
-            {renderProductName()}
-            {this.renderVersion()}
+        return <div className='gs-header tide-welcome-header'>
+            <div className='theia-icon tide-welcome-icon'>
+            </div>
+            <div>
+                {renderProductName()}
+                {this.renderVersion()}
+            </div>
         </div>;
     }
 
+    /**
+     * Both versions go on a single line, so that the header stays as flat as the sections below it.
+     */
     protected renderVersion(): React.ReactNode {
-        return <div>
-            <p className='gs-sub-header' >
-                {this.applicationInfo ? 'Version ' + this.applicationInfo.version : '-'}
-            </p>
-
-            <p className='gs-sub-header' >
-                {'VS Code API Version: ' + this.vscodeApiVersion}
-            </p>
-        </div>;
-    }
-
-    protected renderAIBanner(): React.ReactNode {
-        const framework = super.renderAIBanner();
-        if (React.isValidElement<React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>>(framework)) {
-            return React.cloneElement(framework, { className: 'gs-section' });
-        }
-        return framework;
+        return <p className='gs-sub-header'>
+            {'Version ' + (this.applicationInfo?.version ?? '-') + ' · VS Code API ' + (this.vscodeApiVersion ?? '-')}
+        </p>;
     }
 }

--- a/theia-extensions/updater/src/electron-browser/updater/theia-updater-frontend-contribution.ts
+++ b/theia-extensions/updater/src/electron-browser/updater/theia-updater-frontend-contribution.ts
@@ -45,7 +45,15 @@ export namespace TheiaUpdaterCommands {
 }
 
 export namespace TheiaUpdaterMenu {
-    export const MENU_PATH: MenuPath = [...CommonMenus.FILE_SETTINGS_SUBMENU, '3_settings_submenu_update'];
+    /**
+     * `Help` is where desktop applications conventionally offer the update check, VS Code included. On macOS
+     * it would belong in the application menu, but Theia builds that one from a fixed template, so `Help` is
+     * used on every platform.
+     *
+     * The entries go straight into `Help` rather than into a group of their own: a group is positioned by its
+     * id, so only an action registered directly can be placed with an `order`.
+     */
+    export const MENU_PATH: MenuPath = CommonMenus.HELP;
 }
 
 @injectable()
@@ -182,11 +190,14 @@ export class TheiaUpdaterFrontendContribution implements CommandContribution, Me
     }
 
     registerMenus(registry: MenuModelRegistry): void {
+        // `z` keeps the update entries at the bottom of `Help`, below `About`, which core registers with `9`.
         registry.registerMenuAction(TheiaUpdaterMenu.MENU_PATH, {
-            commandId: TheiaUpdaterCommands.CHECK_FOR_UPDATES.id
+            commandId: TheiaUpdaterCommands.CHECK_FOR_UPDATES.id,
+            order: 'z1'
         });
         registry.registerMenuAction(TheiaUpdaterMenu.MENU_PATH, {
-            commandId: TheiaUpdaterCommands.RESTART_TO_UPDATE.id
+            commandId: TheiaUpdaterCommands.RESTART_TO_UPDATE.id,
+            order: 'z2'
         });
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Enables the VS Code `contributes.walkthroughs` contribution point in the Theia IDE, which
requires Theia 1.75.0-next.25 (eclipse-theia/theia#17309), and reworks the welcome page
around it.

The welcome page overrode `render` completely and never called `renderWalkthroughs`, so
walkthroughs stayed invisible. Adding a card list to the previous single column of ten prose
sections would only have made it longer, so the page is restructured at the same time:

- Two columns, what you can do on the left and what the IDE is on the right, folding to one
  column on a narrow editor. A selected walkthrough takes over the whole view.
- The header shows the square application icon next to the product name instead of the
  wordmark logo, and the product name is colored per branding variant. The welcome tab
  carries the application icon as well.
- The description sections are condensed, their links are inline, and they are now shared
  with the About dialog so both describe the product in the same words.
- `Check for Updates` and `Restart to Update` move from `File > Preferences` to `Help`.

Note for reviewers: the `Updates` section and the `Help` menu entries are Electron only,
since the updater extension ships with the desktop builds.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. `yarn && yarn build:extensions && yarn browser build && yarn browser start`
2. The welcome page shows a `Walkthroughs` section with one card, `Get Started with Java
   Development` from the bundled `vscjava.vscode-java-pack`. Clicking it fills the view, the
   tab is renamed `Walkthrough: …`, and `Back` returns. Step content, media and links render;
   toggling a step and `Mark Done` update the progress, which survives a reload.
3. `Open Walkthrough...` and `Reset Walkthrough Progress` from the command palette offer a picker.
4. Narrow the editor area and confirm the layout folds to one column without clipping. Check a
   light, a dark and a high contrast theme.
5. `Help > About` shows the same description sections as the welcome page.
6. `yarn electron build && yarn electron start`: `Help` offers `Check for Updates...` at the
   bottom, and the welcome page has an `Updates` section whose `check for updates` link runs it.
7. In an `electron-next` build, the application icon and the `IDE` in the product name are purple.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

