### PR TITLE
chore: raise minimum Node.js version to 24

### DIFF
--- a/applications/browser/package.json
+++ b/applications/browser/package.json
@@ -16,7 +16,7 @@
   },
   "engines": {
     "yarn": ">=1.7.0 <2",
-    "node": ">=22"
+    "node": ">=24"
   },
   "theia": {
     "frontend": {

--- a/applications/electron-next/package.json
+++ b/applications/electron-next/package.json
@@ -17,7 +17,7 @@
   },
   "engines": {
     "yarn": ">=1.7.0 <2",
-    "node": ">=22"
+    "node": ">=24"
   },
   "theia": {
     "target": "electron",

--- a/applications/electron/package.json
+++ b/applications/electron/package.json
@@ -17,7 +17,7 @@
   },
   "engines": {
     "yarn": ">=1.7.0 <2",
-    "node": ">=22"
+    "node": ">=24"
   },
   "theia": {
     "target": "electron",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "engines": {
     "yarn": ">=1.7.0 <2",
-    "node": ">=22"
+    "node": ">=24"
   },
   "devDependencies": {
     "@eclipse-dash/nodejs-wrapper": "^0.0.1",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Follow-up to eclipse-theia/theia#17588. Bumps engines.node from `>=22` to
`>=24` across the root and application package.json files. CI, next builds
and the builder image already run on Node 24.

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->


#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

