### PR TITLE
fix: build Theia IDE mac installer with Node 24

### DIFF
--- a/releng/preview/Jenkinsfile.build
+++ b/releng/preview/Jenkinsfile.build
@@ -105,7 +105,7 @@ spec:
                         label 'macos'
                     }
                     steps {
-                        nodejs(nodeJSInstallationName: 'node_22.x') {
+                        nodejs(nodeJSInstallationName: 'node_24.x') {
                             script {
                                 sh "node --version"
                                 createMacInstaller()


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

Follow up of #770 

- switch the mac stage from the node_22.x to the node_24.x Jenkins tool installation

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

See https://ci.eclipse.org/theia/job/theia-ide-release/117/stages/?selected-node=35 and confirm the stage prints `v24.x` for `node --version` and completes `yarn install` now.
(the jenkins job temporarily points to this branch, will revert to master after this has been merged)

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

