### PR TITLE
fix: update the blockmap with the app-builder-lib API

### DIFF
--- a/applications/electron/scripts/update-blockmap.ts
+++ b/applications/electron/scripts/update-blockmap.ts
@@ -9,9 +9,7 @@
 
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs/yargs';
-import { executeAppBuilderAsJson } from 'app-builder-lib/out/util/appBuilder';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { BlockMapDataHolder } from 'builder-util-runtime';
+import { buildBlockMap } from 'app-builder-lib/out/targets/blockmap/blockmap';
 import { rmSync } from 'fs';
 import * as path from 'path';
 
@@ -39,5 +37,6 @@ async function execute(): Promise<void> {
     rmSync(blockMapFile, {
         force: true,
     });
-    await executeAppBuilderAsJson<BlockMapDataHolder>(['blockmap', '--input', executablePath, '--output', blockMapFile]);
+    // 'gzip' matches what electron-builder itself uses when it writes a separate .blockmap file.
+    await buildBlockMap(executablePath, 'gzip', blockMapFile);
 };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

electron-builder 26.15 dropped the bundled `app-builder` binary and reimplemented the blockmap generation in TypeScript, which removed `app-builder-lib/out/util/appBuilder`. The upload job therefore failed with `TS2307: Cannot find module 'app-builder-lib/out/util/appBuilder'`.

Call `buildBlockMap` instead, with the same gzip compression that electron-builder uses when it writes a separate `.blockmap` file.

This came in with the dependency upgrade after v1.74.100, which bumped `app-builder-lib` from 26.0.12 to 26.15.3. Nothing failed at build time because the script only runs in the upload job.

#### How to test

Ran the upload job against this branch: https://ci.eclipse.org/theia/job/theia-ide-upload/55/
The `update:blockmap` and `update:checksum` steps now complete for mac-arm64 (zip and dmg) and `latest-mac.yml` is updated with the new checksums and sizes, see https://download.eclipse.org/theia/ide-preview/1.75.0/

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

