### PR TITLE
chore: automate more manual steps of the publishing guide

### DIFF
--- a/.github/workflows/build-next-release.yml
+++ b/.github/workflows/build-next-release.yml
@@ -31,20 +31,21 @@ jobs:
       - name: Export build variables
         shell: bash
         run: |
-          THEIA_VERSION=next
-          echo "THEIA_VERSION=${THEIA_VERSION}" >> $GITHUB_ENV
-          yarn version --minor --no-git-tag-version
-          IDE_VERSION=$(jq -r .version package.json)
-          echo "THEIA_IDE_VERSION=${IDE_VERSION}-next-$(date +%Y-%m-%d)" >> $GITHUB_ENV
+          # Build against the version currently published under the Theia `next` dist tag, e.g.
+          # 1.76.0-next.0, and publish the IDE as a dated pre-release of the same upcoming release.
+          THEIA_NEXT=$(npm view @theia/core@next version)
+          if [ -z "$THEIA_NEXT" ]; then
+            echo "Could not resolve the version published under the Theia 'next' dist tag." >&2
+            exit 1
+          fi
+          echo "THEIA_VERSION=${THEIA_NEXT}" >> $GITHUB_ENV
+          echo "THEIA_IDE_VERSION=${THEIA_NEXT%%-*}-next-$(date -u +%Y-%m-%d)" >> $GITHUB_ENV
 
       - name: Build next package
         shell: bash
         run: |
           yarn --skip-integrity-check --network-timeout 100000
-          yarn version --new-version $THEIA_IDE_VERSION --no-git-tag-version
-          yarn lerna version $THEIA_IDE_VERSION --no-push --no-git-tag-version --yes
-          yarn update:theia $THEIA_VERSION && yarn update:theia:children $THEIA_VERSION
-          yarn --skip-integrity-check --network-timeout 100000
+          yarn release:prepare --theia $THEIA_VERSION --ide $THEIA_IDE_VERSION
           yarn build:extensions
           yarn build:applications:next
           yarn download:plugins

--- a/.github/workflows/build-next.yml
+++ b/.github/workflows/build-next.yml
@@ -35,10 +35,15 @@ jobs:
       - name: Export build variables
         shell: bash
         run: |
-          THEIA_VERSION=next
-          echo "THEIA_VERSION=${THEIA_VERSION}" >> $GITHUB_ENV
-          yarn version --minor --no-git-tag-version
-          echo "THEIA_IDE_VERSION=$(jq -r .version package.json)-${THEIA_VERSION}-$(date +%d-%m-%y)" >> $GITHUB_ENV
+          # Build against the version currently published under the Theia `next` dist tag, e.g.
+          # 1.76.0-next.0, and build the IDE as a dated pre-release of the same upcoming release.
+          THEIA_NEXT=$(npm view @theia/core@next version)
+          if [ -z "$THEIA_NEXT" ]; then
+            echo "Could not resolve the version published under the Theia 'next' dist tag." >&2
+            exit 1
+          fi
+          echo "THEIA_VERSION=${THEIA_NEXT}" >> $GITHUB_ENV
+          echo "THEIA_IDE_VERSION=${THEIA_NEXT%%-*}-next-$(date -u +%Y-%m-%d)" >> $GITHUB_ENV
 
       - name: Update electron-builder.yml for macos-15
         if: matrix.os == 'macos-15'
@@ -49,10 +54,7 @@ jobs:
         shell: bash
         run: |
           yarn --skip-integrity-check --network-timeout 100000
-          yarn version --new-version $THEIA_IDE_VERSION --no-git-tag-version
-          yarn lerna version $THEIA_IDE_VERSION --no-push --no-git-tag-version --yes
-          yarn update:theia $THEIA_VERSION && yarn update:theia:children $THEIA_VERSION
-          yarn --skip-integrity-check --network-timeout 100000
+          yarn release:prepare --theia $THEIA_VERSION --ide $THEIA_IDE_VERSION
           yarn build
           yarn download:plugins
           yarn package:applications

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,11 @@ on:
       - '**/*.md'
       - 'TheiaIDE logo/**'
   workflow_dispatch:
+    inputs:
+      upload_mac_artifacts:
+        description: "Upload the mac artifacts to the rolling 'pre-release' (PUBLISHING.md step 2.5)"
+        type: boolean
+        default: false
   pull_request:
     branches:
       - master
@@ -29,6 +34,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout
@@ -149,3 +157,44 @@ jobs:
           path: applications/electron/test-screenshots/
           if-no-files-found: ignore
           retention-days: 5
+
+  # PUBLISHING.md 2.5: provides the unsigned mac dmgs as input for the Jenkins release build.
+  # Kept as a separate job so that only this step runs with a writable token.
+  upload-mac-artifacts:
+    name: Publish mac artifacts to the rolling pre-release
+    if: ${{ inputs.upload_mac_artifacts }}
+    needs: build
+    runs-on: ubuntu-22.04
+    timeout-minutes: 30
+
+    permissions:
+      contents: write # required to replace the assets of the 'pre-release'
+
+    strategy:
+      fail-fast: false
+      matrix:
+        artifact: [mac-x64, mac-arm64]
+
+    steps:
+      # Downloaded as-is: the artifact zip is already the asset that the Jenkins build unzips.
+      - name: Download ${{ matrix.artifact }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ matrix.artifact }}
+          path: download
+          skip-decompress: true
+
+      # Replaces the asset in place, so the 'pre-release' tag stays stable as input for the Jenkins jobs.
+      - name: Replace ${{ matrix.artifact }}.zip on the pre-release
+        shell: bash
+        run: |
+          DOWNLOADED=$(find download -name '*.zip' -print -quit)
+          if [ -z "$DOWNLOADED" ]; then
+            echo "No zip found in the downloaded '${{ matrix.artifact }}' artifact." >&2
+            exit 1
+          fi
+          ASSET="$RUNNER_TEMP/${{ matrix.artifact }}.zip"
+          mv "$DOWNLOADED" "$ASSET"
+          gh release upload pre-release "$ASSET" --clobber --repo "$GITHUB_REPOSITORY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -67,6 +67,21 @@ yarn
 ### 2.2. Update versions
 <!-- release: both -->
 
+Determine **THEIA_IDE_VERSION** as described in [1. Overview](#1-overview), then run the release preparation script with both versions:
+
+```sh
+yarn release:prepare --theia {{version}} --ide {{ideVersion}}
+```
+
+It updates the monorepo version, all package versions, the Theia dependencies and the yarn lock file. It never derives a version, both are taken exactly as passed.
+
+- Omit `--theia` if there is no new Theia release to consume, `--ide` is always required.
+- Add `--dry-run` to print the versions and the commands without running them.
+
+Review the resulting diff before continuing, it should only contain version changes.
+
+Optional: the manual steps would be:
+
 1. Update the monorepo version to **THEIA_IDE_VERSION** (without creating a Git tag):
 
    ```sh

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -73,7 +73,7 @@ Determine **THEIA_IDE_VERSION** as described in [1. Overview](#1-overview), then
 yarn release:prepare --theia {{version}} --ide {{ideVersion}}
 ```
 
-It updates the monorepo version, all package versions, the Theia dependencies and the yarn lock file. It never derives a version, both are taken exactly as passed.
+It updates the monorepo version, all package versions, the Theia dependencies, the versioned `@theia` patch file names and the yarn lock file. It never derives a version, both are taken exactly as passed.
 
 - Omit `--theia` if there is no new Theia release to consume, `--ide` is always required.
 - Add `--dry-run` to print the versions and the commands without running them.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -139,11 +139,11 @@ After completing step 2.3, open a PR with your changes <https://github.com/eclip
 ### 2.5. Mac Artifacts
 <!-- release: both -->
 
-- The PR will trigger a verification build that generates two zip files with mac artifacts.
-- Download these two zips and replace them in this pre-release: <https://github.com/eclipse-theia/theia-ide/releases/tag/pre-release>.
-- These unsigned dmgs will be used as input for the Jenkins build.
+The Jenkins build does not build the mac app itself, it downloads the unsigned dmgs from this pre-release and signs them: <https://github.com/eclipse-theia/theia-ide/releases/tag/pre-release>. Its `mac-x64.zip` and `mac-arm64.zip` assets therefore have to be replaced with the artifacts of the release build.
 
-> **Patch release branch:** If using a `release/{{version}}` branch, manually trigger the [Build, package and test](https://github.com/eclipse-theia/theia-ide/actions/workflows/build.yml) workflow targeting the `release/{{version}}` branch to generate the mac artifacts (no PR build is triggered automatically).
+Trigger the [Build, package and test](https://github.com/eclipse-theia/theia-ide/actions/workflows/build.yml) workflow on the release branch (the head branch of the release PR, or `release/{{version}}` for a patch release) and enable the **Upload the mac artifacts to the rolling 'pre-release'** option. Once the build is green on all platforms, it replaces both assets in place.
+
+Optional: the manual steps would be to download the two zip files from the run, which the build uploads as regular workflow artifacts on pull request builds as well, and to replace the two pre-release assets by hand.
 
 ### 2.6. Merge Release PR & Trigger Jenkins Build
 <!-- release: both -->

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "update:theia": "ts-node scripts/update-theia-version.ts",
     "update:theia:children": "lerna run update:theia -- ",
     "update:next": "ts-node scripts/update-theia-version.ts next && lerna run update:next",
+    "release:prepare": "ts-node scripts/prepare-release.ts",
     "lint": "eslint --ext js,jsx,ts,tsx scripts && lerna run lint",
     "lint:fix": "eslint --ext js,jsx,ts,tsx scripts --fix && lerna run lint:fix",
     "license:check:fetch-jar": "node scripts/fetch-dash-licenses-jar.js",

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -1,0 +1,107 @@
+/********************************************************************************
+ * Copyright (C) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ *
+ * SPDX-License-Identifier: MIT
+ ********************************************************************************/
+
+import { execSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { PackageJson } from 'type-fest';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+
+/** A release version, optionally with a pre-release and a build part, e.g. `1.76.0-next.0`. */
+const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
+/** An npm dist tag, e.g. `next` or `latest`. */
+const DIST_TAG_PATTERN = /^[A-Za-z][A-Za-z0-9-]*$/;
+
+const argv = yargs(hideBin(process.argv))
+    .option('theia', {
+        alias: 't',
+        type: 'string',
+        description: 'THEIA_VERSION to consume, e.g. 1.76.0, 1.76.0-next.0 or the dist tag next. '
+            + 'Omit if there is no new Theia release to consume',
+    })
+    .option('ide', {
+        alias: 'i',
+        type: 'string',
+        demandOption: true,
+        description: 'THEIA_IDE_VERSION to publish, e.g. 1.76.0 or 1.76.0-next.0. '
+            + 'See section 1 of PUBLISHING.md for how to determine it',
+    })
+    .option('dry-run', {
+        type: 'boolean',
+        default: false,
+        description: 'Print the resolved versions and the commands, but do not run them',
+    })
+    .version(false)
+    .wrap(120)
+    .parseSync();
+
+execute();
+
+function execute(): void {
+    try {
+        const currentVersion = readCurrentVersion();
+        const theiaVersion = argv.theia;
+        const ideVersion = argv.ide;
+        assertVersions(theiaVersion, ideVersion);
+
+        console.log(`Current Theia IDE version: ${currentVersion}`);
+        console.log(`THEIA_IDE_VERSION:         ${ideVersion}`);
+        console.log(`THEIA_VERSION:             ${theiaVersion ?? '(unchanged)'}`);
+        console.log('');
+
+        // 2.1 Install build dependencies
+        run('yarn');
+
+        // 2.2 Update versions
+        if (ideVersion !== currentVersion) {
+            run(`yarn version --no-git-tag-version --new-version ${ideVersion}`);
+        } else {
+            console.log(`Skipping the monorepo version update, package.json is already at ${ideVersion}.`);
+        }
+        if (theiaVersion) {
+            run(`yarn update:theia ${theiaVersion}`);
+            run(`yarn update:theia:children ${theiaVersion}`);
+        }
+        run(`yarn lerna version ${ideVersion} --exact --no-push --no-git-tag-version --yes`);
+        run('yarn');
+    } catch (error) {
+        console.error(`Failed to prepare the release: ${error.message}`);
+        process.exit(1);
+    }
+}
+
+function readCurrentVersion(): string {
+    const packageJsonPath = path.resolve('./', 'package.json');
+    const packageJson: PackageJson = JSON.parse(fs.readFileSync(packageJsonPath, { encoding: 'utf8' }));
+    const version = packageJson.version;
+    if (!version || !VERSION_PATTERN.test(version)) {
+        throw new Error(`Could not read a valid version from ${packageJsonPath}. Run this script from the repository root.`);
+    }
+    return version;
+}
+
+/** Both versions are always passed in, the script never derives or guesses a version. */
+function assertVersions(theiaVersion: string | undefined, ideVersion: string): void {
+    if (!VERSION_PATTERN.test(ideVersion)) {
+        throw new Error(`'--ide ${ideVersion}' is not a valid version. Expected 'major.minor.patch', e.g. '1.76.0' or '1.76.0-next.0'.`);
+    }
+    if (theiaVersion && !VERSION_PATTERN.test(theiaVersion) && !DIST_TAG_PATTERN.test(theiaVersion)) {
+        throw new Error(`'--theia ${theiaVersion}' is neither a version nor a dist tag. Expected e.g. '1.76.0', '1.76.0-next.0' or 'next'.`);
+    }
+}
+
+function run(command: string): void {
+    if (argv.dryRun) {
+        console.log(`[dry run] ${command}`);
+        return;
+    }
+    console.log(`> ${command}`);
+    execSync(command, { stdio: 'inherit' });
+}

--- a/scripts/prepare-release.ts
+++ b/scripts/prepare-release.ts
@@ -18,6 +18,8 @@ import { hideBin } from 'yargs/helpers';
 const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
 /** An npm dist tag, e.g. `next` or `latest`. */
 const DIST_TAG_PATTERN = /^[A-Za-z][A-Za-z0-9-]*$/;
+/** A `patch-package` file for a Theia package, e.g. `@theia+terminal+1.75.0.patch`. */
+const THEIA_PATCH_PATTERN = /^(@theia\+[^+]+)\+(\d+\.\d+\.\d+.*)\.patch$/;
 
 const argv = yargs(hideBin(process.argv))
     .option('theia', {
@@ -68,6 +70,7 @@ function execute(): void {
         if (theiaVersion) {
             run(`yarn update:theia ${theiaVersion}`);
             run(`yarn update:theia:children ${theiaVersion}`);
+            renameTheiaPatches(theiaVersion);
         }
         run(`yarn lerna version ${ideVersion} --exact --no-push --no-git-tag-version --yes`);
         run('yarn');
@@ -94,6 +97,33 @@ function assertVersions(theiaVersion: string | undefined, ideVersion: string): v
     }
     if (theiaVersion && !VERSION_PATTERN.test(theiaVersion) && !DIST_TAG_PATTERN.test(theiaVersion)) {
         throw new Error(`'--theia ${theiaVersion}' is neither a version nor a dist tag. Expected e.g. '1.76.0', '1.76.0-next.0' or 'next'.`);
+    }
+}
+
+/**
+ * `patch-package` reads the package version from the patch file name, so a patch that keeps the
+ * previous version in its name is applied with a mismatch warning. Rename the Theia patches along
+ * with the dependencies, before the lock file is refreshed and the patches are applied again.
+ */
+function renameTheiaPatches(theiaVersion: string): void {
+    if (!VERSION_PATTERN.test(theiaVersion)) {
+        console.log(`Skipping the patch file rename, the dist tag '${theiaVersion}' does not name a version.`);
+        return;
+    }
+    const patchesDir = path.resolve('./', 'patches');
+    if (!fs.existsSync(patchesDir)) {
+        return;
+    }
+    for (const patch of fs.readdirSync(patchesDir)) {
+        const match = THEIA_PATCH_PATTERN.exec(patch);
+        if (!match || match[2] === theiaVersion) {
+            continue;
+        }
+        const renamed = `${match[1]}+${theiaVersion}.patch`;
+        console.log(`${argv.dryRun ? '[dry run] ' : ''}Renaming ${patch} to ${renamed}`);
+        if (!argv.dryRun) {
+            fs.renameSync(path.join(patchesDir, patch), path.join(patchesDir, renamed));
+        }
     }
 }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does
<!-- Include relevant issues and describe how they are addressed. -->

feat: add a release:prepare script for the version updates 

- prefer the script over the manual steps in PUBLISHING.md
- use the script in the next workflows, which now resolve the Theia
  version from the last `next` dist tag

feat: upload the mac artifacts to the pre-release from the build 

- add an `upload_mac_artifacts` option that replaces the mac zips on the
  rolling `pre-release`, instead of the manual download and re-upload in
  PUBLISHING.md step 2.5
- upload the artifact zip as-is, that is what the Jenkins build unzips
- scope the workflow token: `contents: read` for the build matrix,
  `contents: write` only for the separate upload job

feat: rename the versioned @Theia patch files on release:prepare 

- `patch-package` reads the package version from the patch file name, so
  a stale name is applied with a version mismatch warning
- rename right after the Theia dependencies and before the lock file
  refresh, which is when the patches are applied again
- skipped for dist tags, they do not name a version

#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Test the new `release:prepare` script locally, e.g. via `yarn release:prepare --theia 1.76.0-next.0 --ide 1.76.0-next-2026-08-28 --dry-run`
2. Check the test run of the 1.75.0 build (https://github.com/eclipse-theia/theia-ide/actions/runs/33173690602) which uploaded the mac artifacts successfully to: https://github.com/eclipse-theia/theia-ide/releases/tag/pre-release

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] as an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- as a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

